### PR TITLE
補充 Agent 模組介面與 A2A 容錯策略

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,251 @@ README.md 已詳細定義系統中的核心腳色，下列為其概要：
 - **群眾 Agent（The Masses）**：模擬不同社會群體的資訊傳播行為。
 - **謠言製造者 Agent（The Disrupter）**：注入迷惑性訊息以測試系統韌性。
 
+## 各 Agent 模組介面與資料結構範例
+以下示範主要 Agent 的輸入、輸出資料型別與呼叫順序，所有範例皆使用 TypeScript 風格並以繁體中文註解。
+
+### The Curator
+負責將原始文章轉為實體與情緒資訊。
+
+#### 介面
+```typescript
+interface CuratorInput {
+  rawText: string // 原始文章內容
+}
+
+interface CuratorOutput {
+  entities: string[] // 萃取的實體列表
+  sentiment: string // 情緒極性
+}
+
+interface Curator {
+  process(input: CuratorInput): Promise<CuratorOutput> // 處理輸入並回傳結果
+}
+```
+
+#### 資料結構範例
+```jsonc
+{
+  "origin": "User",
+  "target": "The Curator",
+  "content": "新聞全文", // 原始輸入文字
+  "attention_cost": 1,
+  "trace_id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+#### 呼叫順序圖
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant C as Curator
+    P->>C: 原始訊息
+    C-->>P: 實體與情緒
+```
+
+### The Advocate
+為新聞內容提供佐證與辯護。
+
+#### 介面
+```typescript
+interface AdvocateInput {
+  facts: string[] // 已知事實
+  article: string // 文章片段
+}
+
+interface AdvocateOutput {
+  arguments: string[] // 支持論點
+}
+
+interface Advocate {
+  defend(input: AdvocateInput): Promise<AdvocateOutput> // 生成辯護內容
+}
+```
+
+#### 資料結構範例
+```jsonc
+{
+  "origin": "The Curator",
+  "target": "The Advocate",
+  "content": {
+    "facts": ["實體1", "實體2"], // 前置事實
+    "article": "文章片段"
+  },
+  "attention_cost": 2,
+  "trace_id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+#### 呼叫順序圖
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant A as Advocate
+    P->>A: 結構化資料
+    A-->>P: 支持論點
+```
+
+### The Skeptic
+負責檢驗矛盾與錯誤。
+
+#### 介面
+```typescript
+interface SkepticInput {
+  claims: string[] // 待檢驗的論點
+}
+
+interface SkepticOutput {
+  challenges: string[] // 挑戰與質疑
+}
+
+interface Skeptic {
+  question(input: SkepticInput): Promise<SkepticOutput> // 提出反駁
+}
+```
+
+#### 資料結構範例
+```jsonc
+{
+  "origin": "The Advocate",
+  "target": "The Skeptic",
+  "content": { "claims": ["論點A"] }, // 需要檢驗的主張
+  "attention_cost": 2,
+  "trace_id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+#### 呼叫順序圖
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant S as Skeptic
+    P->>S: 論點資料
+    S-->>P: 挑戰結果
+```
+
+### The Arbiter
+根據辯論與傳播數據進行評分。
+
+#### 介面
+```typescript
+interface ArbiterInput {
+  debates: string[] // 辯論內容
+  traces: string[] // 傳播軌跡
+}
+
+interface ArbiterOutput {
+  score: number // 客觀評分
+  verdict: string // 裁決結論
+}
+
+interface Arbiter {
+  judge(input: ArbiterInput): Promise<ArbiterOutput> // 產生評分與裁決
+}
+```
+
+#### 資料結構範例
+```jsonc
+{
+  "origin": "The Skeptic",
+  "target": "The Arbiter",
+  "content": {
+    "debates": ["正反意見"],
+    "traces": ["trace_id"]
+  },
+  "attention_cost": 3,
+  "trace_id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+#### 呼叫順序圖
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant R as Arbiter
+    P->>R: 辯論與軌跡
+    R-->>P: 評分與裁決
+```
+
+### The Masses
+模擬群眾的資訊傳播行為。
+
+#### 介面
+```typescript
+interface MassesInput {
+  message: string // 需要擴散的訊息
+  demographics: string[] // 群眾族群
+}
+
+interface MassesOutput {
+  spread: Record<string, number> // 各族群的傳播率
+}
+
+interface Masses {
+  simulate(input: MassesInput): Promise<MassesOutput> // 模擬傳播
+}
+```
+
+#### 資料結構範例
+```jsonc
+{
+  "origin": "The Arbiter",
+  "target": "The Masses",
+  "content": {
+    "message": "評分結果",
+    "demographics": ["族群A", "族群B"]
+  },
+  "attention_cost": 1,
+  "trace_id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+#### 呼叫順序圖
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant M as Masses
+    P->>M: 傳播指令
+    M-->>P: 族群回應
+```
+
+### The Disrupter
+模擬謠言或迷惑性訊息。
+
+#### 介面
+```typescript
+interface DisrupterInput {
+  topic: string // 目標議題
+}
+
+interface DisrupterOutput {
+  rumor: string // 生成的謠言
+}
+
+interface Disrupter {
+  inject(input: DisrupterInput): Promise<DisrupterOutput> // 注入訊息
+}
+```
+
+#### 資料結構範例
+```jsonc
+{
+  "origin": "Pipeline",
+  "target": "The Disrupter",
+  "content": { "topic": "議題X" }, // 需要操作的主題
+  "attention_cost": 1,
+  "trace_id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+#### 呼叫順序圖
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant D as Disrupter
+    P->>D: 觸發議題
+    D-->>P: 生成謠言
+```
+
 ## 使用 Google SDK／Gemini API 的資料流程
 1. 外部系統提供輸入給資料預處理模組。
 2. Pipeline 將處理後的提示詞送往 GeminiClient。
@@ -37,6 +282,21 @@ sequenceDiagram
     P-->>A: 傳遞回應
 ```
 
+### 連線設定、權杖管理與可擴充性
+- **環境變數**：透過 `GOOGLE_APPLICATION_CREDENTIALS` 指向服務帳戶金鑰，並以 `GEMINI_API_KEY` 讀取 Gemini 權杖。
+- **連線池**：GeminiClient 可配置 HTTP 連線池以重複使用連線，降低延遲。
+- **權杖輪替**：Pipeline 可定期輪替 `GEMINI_API_KEY`，並於失效時自動刷新。
+- **多專案支援**：透過設定 `projectId`，可動態切換 Google Cloud 專案以分散配額。
+
+```typescript
+const client = new GeminiClient({
+  apiKey: process.env.GEMINI_API_KEY!, // 從環境變數讀取權杖
+  projectId: process.env.GOOGLE_PROJECT_ID // 指定雲端專案
+})
+```
+
+此設計允許日後替換為其他 LLM 供應商，僅需實作相容的 Client 介面並註冊於 Pipeline。
+
 ## A2A 串聯設計與迴圈控制
 1. **訊息標準化**：Pipeline 將每則訊息包裝為含 `origin`、`target`、`content`、`attention_cost` 與 `trace_id` 的結構，確保後續 Agent 能正確解析。
 2. **流程圖驅動**：根據預先定義的流程圖，Pipeline 決定下一個 Agent，並將 `trace_id` 寫入傳播軌跡紀錄。
@@ -44,6 +304,24 @@ sequenceDiagram
 4. **多維度判斷**：陪審團 Agent 不僅接收辯論內容，還會從傳播軌跡資料庫擷取 `trace_id` 與關聯度，以建立更全面的評分依據。
 5. **仲裁終止條件**：若所有參與 Agent 的注意力資源耗盡、達到最大回合數，或陪審團給出最終決議，Pipeline 即終止串聯並輸出結果。
 6. **迴圈偵測**：Pipeline 會計算訊息內容的雜湊值，若相同訊息在相同路徑重複出現，將觸發警示並交由陪審團判斷是否提前結束流程。
+
+## A2A 可能的錯誤情境與容錯策略
+- **Agent 超時**：若代理在指定時間內無回應，Pipeline 會重試三次，仍失敗則交由備援 Agent 處理。
+- **API 配額耗盡**：GeminiClient 回報配額錯誤時，Pipeline 啟動排程延遲並通知監控系統。
+- **資料格式錯誤**：訊息驗證失敗時，Pipeline 會回傳錯誤並中止該路徑，避免污染後續 Agent。
+- **重複訊息**：偵測到相同 `trace_id` 與內容時，觸發循環警示並交由陪審團決定是否終止。
+
+```mermaid
+sequenceDiagram
+    participant P as Pipeline
+    participant A1 as Agent甲
+    participant A2 as 備援 Agent乙
+    P->>A1: 傳送訊息
+    A1--xP: 超時/錯誤
+    P->>A1: 重試 (最多3次)
+    P->>A2: 轉交備援
+    A2-->>P: 回傳結果
+```
 
 ## 擴充點、潛在問題與例外處理
 - **擴充點**：


### PR DESCRIPTION
## Summary
- 定義各 Agent 的介面、資料結構範例與呼叫順序圖
- 補充 Google SDK/Gemini API 連線設定與權杖管理
- 加入 A2A 串聯的錯誤情境與容錯時序圖

## Testing
- `npm test` *(失敗：找不到 package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55190cda083238f99af6d4518e265