### PR TITLE
docs: 加入 google-adk 安裝說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ graph TD
 2. 安裝依賴（需先安裝 Google SDK）：
    ```bash
    pip install google-cloud-sdk
+   pip install google-adk
    ```
+   - `google-adk`：用於與 Google Android Development Kit 互動，協助整合相關硬體功能
 3. 執行測試：
    ```bash
    python -m pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+google-adk


### PR DESCRIPTION
## Summary
- 新增 `google-adk` 至 `requirements.txt`
- 在 README 安裝步驟加入 `pip install google-adk` 並說明用途

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5528812588323919c738bd536dc3b