### PR TITLE
新增多個代理類別

### DIFF
--- a/src/agents/advocate.py
+++ b/src/agents/advocate.py
@@ -1,0 +1,26 @@
+from src.base_agent import BaseAgent
+
+
+class Advocate(BaseAgent):
+    """倡議者代理類別
+
+    角色任務：
+        針對特定提案生成正面論述，說服受眾接受該提案。
+
+    輸入資料格式：
+        `proposal` (`str`): 提案內容描述。
+
+    輸出資料格式：
+        `str`: 支持該提案的倡議陳述。
+    """
+
+    def run(self, proposal: str) -> str:
+        """執行倡議流程
+
+        參數:
+            proposal (str): 需要倡議的提案內容。
+
+        回傳:
+            str: 結合正面論點後的倡議文字。
+        """
+        return f"我們應該推動{proposal}，它將帶來顯著的正面影響。"

--- a/src/agents/arbiter.py
+++ b/src/agents/arbiter.py
@@ -1,0 +1,31 @@
+from src.base_agent import BaseAgent
+
+
+class Arbiter(BaseAgent):
+    """仲裁者代理類別
+
+    角色任務：
+        接收多方意見並計算多數決結果，輸出最終裁決。
+
+    輸入資料格式：
+        `opinions` (`list[str]`): 各參與者的意見列表。
+
+    輸出資料格式：
+        `str`: 經過多數決後的裁決結論。
+    """
+
+    def run(self, opinions: list[str]) -> str:
+        """執行仲裁流程
+
+        參數:
+            opinions (list[str]): 各方提出的意見。
+
+        回傳:
+            str: 多數決產生的裁決內容。
+        """
+        if not opinions:
+            return "無可裁決意見"
+
+        # 以出現頻率最高的意見作為裁決
+        decision = max(set(opinions), key=opinions.count)
+        return f"裁決結果：{decision}"

--- a/src/agents/curator.py
+++ b/src/agents/curator.py
@@ -1,0 +1,31 @@
+from src.base_agent import BaseAgent
+
+
+class Curator(BaseAgent):
+    """策展者代理類別
+
+    角色任務：
+        接收多筆文字資料並進行去重與條列整理，提供清晰摘要。
+
+    輸入資料格式：
+        `materials` (`list[str]`): 原始資訊集合。
+
+    輸出資料格式：
+        `list[str]`: 清理後的資訊摘要清單。
+    """
+
+    def run(self, materials: list[str]) -> list[str]:
+        """執行策展流程
+
+        參數:
+            materials (list[str]): 待整理的文字資訊。
+
+        回傳:
+            list[str]: 去重且去除前後空白的資訊摘要。
+        """
+        unique_items = []
+        for item in materials:
+            cleaned = item.strip()
+            if cleaned and cleaned not in unique_items:
+                unique_items.append(cleaned)
+        return unique_items

--- a/src/agents/disrupter.py
+++ b/src/agents/disrupter.py
@@ -1,0 +1,26 @@
+from src.base_agent import BaseAgent
+
+
+class Disrupter(BaseAgent):
+    """破壞者代理類別
+
+    角色任務：
+        針對既定的假設或流程提出反向觀點，促進創新與反思。
+
+    輸入資料格式：
+        `status_quo` (`str`): 目前被視為理所當然的現狀描述。
+
+    輸出資料格式：
+        `str`: 對現狀提出挑戰的疑問或觀點。
+    """
+
+    def run(self, status_quo: str) -> str:
+        """執行破壞流程
+
+        參數:
+            status_quo (str): 需要被質疑或挑戰的現狀。
+
+        回傳:
+            str: 促使重新思考的挑戰語句。
+        """
+        return f"如果我們不再遵循『{status_quo}』，會產生什麼新可能？"

--- a/src/agents/masses.py
+++ b/src/agents/masses.py
@@ -1,0 +1,28 @@
+from src.base_agent import BaseAgent
+
+
+class Masses(BaseAgent):
+    """群眾代理類別
+
+    角色任務：
+        模擬多數群體對議題的回應，產生具代表性的集體觀點。
+
+    輸入資料格式：
+        `question` (`str`): 要詢問群眾的問題。
+        `size` (`int`, 選用): 要模擬的群眾數量，預設為 3。
+
+    輸出資料格式：
+        `list[str]`: 群眾針對問題的各自回應。
+    """
+
+    def run(self, question: str, size: int = 3) -> list[str]:
+        """執行群眾模擬
+
+        參數:
+            question (str): 需要回應的議題內容。
+            size (int): 產生回應的模擬人數。
+
+        回傳:
+            list[str]: 模擬群眾的回應清單。
+        """
+        return [f"群眾{i + 1}：對『{question}』的看法" for i in range(size)]

--- a/src/agents/skeptic.py
+++ b/src/agents/skeptic.py
@@ -1,0 +1,26 @@
+from src.base_agent import BaseAgent
+
+
+class Skeptic(BaseAgent):
+    """懷疑者代理類別
+
+    角色任務：
+        針對主張提出質疑，檢驗論點的完整性與可靠度。
+
+    輸入資料格式：
+        `claim` (`str`): 需要被質疑的主張內容。
+
+    輸出資料格式：
+        `str`: 懷疑者提出的關鍵質疑句。
+    """
+
+    def run(self, claim: str) -> str:
+        """執行質疑流程
+
+        參數:
+            claim (str): 目標主張。
+
+        回傳:
+            str: 引導重新檢視主張的疑問句。
+        """
+        return f"我們有足夠證據支持『{claim}』嗎？"

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -12,6 +13,14 @@ class BaseAgent(ABC):
     attention_budget: int
 
     @abstractmethod
-    def run(self) -> None:
-        """執行代理的主要流程，子類別須實作此方法"""
+    def run(self, data: Any | None = None) -> Any:
+        """執行代理的主要流程
+
+        參數:
+            data (Any | None):
+                執行所需的輸入資料，型別與結構由子類別自行定義。
+
+        回傳:
+            Any: 依子類別設計回傳相應的結果資料。
+        """
         raise NotImplementedError


### PR DESCRIPTION
## 摘要
- 擴充 `BaseAgent` 的 `run` 介面以支援輸入與回傳結果
- 精細化 Curator、Advocate、Skeptic、Arbiter、Masses、Disrupter 的任務與資料格式

## 測試
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a32c59488323b8103870be5e7aab