### PR TITLE
feat: 導入 google.adk 並新增 Runner

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,66 @@
+"""Runner 設定範例
+
+此範例示範如何建立即時保留對話上下文與長期記憶的 Runner，
+並透過事件回呼監控工具調用與模型回覆。
+"""
+
+from google.adk import Agent, Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.memory import InMemoryMemoryService
+from google.adk.events.event import Event
+from google.adk.plugins.base_plugin import BasePlugin
+from google.genai.types import Content, Part
+
+
+class EchoAgent(Agent):
+    """回聲代理，只回傳使用者輸入文字"""
+
+    def run(self, text: str) -> str:
+        """回傳相同內容，示範用"""
+        return f"回應：{text}"
+
+
+class MonitorPlugin(BasePlugin):
+    """簡易事件監聽插件，用於後續監控或 Guardrail 擴充"""
+
+    async def on_event_callback(self, *, invocation_context, event: Event):
+        """監聽工具調用與模型回覆"""
+        # 檢查是否有工具被呼叫
+        for fn in event.get_function_calls():
+            print(f"工具呼叫：{fn.name}")
+
+        # 監控模型回覆（非使用者事件）
+        if event.author != "user":
+            print(f"模型回覆：{event.content}")
+
+        return None
+
+
+# 建立 Session 與 Memory 服務
+session_service = InMemorySessionService()
+memory_service = InMemoryMemoryService()
+
+
+# 建立 Runner，確保對話上下文與記憶保留
+runner = Runner(
+    app_name="agent-judge-demo",
+    agent=EchoAgent(name="echo", model="gemini-1.5-flash"),
+    session_service=session_service,
+    memory_service=memory_service,
+    plugins=[MonitorPlugin()],
+)
+
+
+async def demo() -> None:
+    """示範如何使用 Runner 進行一次對話"""
+
+    # 準備使用者訊息
+    message = Content(role="user", parts=[Part.from_text("你好")])
+
+    # 執行對話流程並處理事件
+    async for event in runner.run_async(
+        user_id="demo-user", session_id="demo-session", new_message=message
+    ):
+        # 此處可進一步處理事件，例如顯示或儲存
+        pass
+

--- a/src/agents/advocate.py
+++ b/src/agents/advocate.py
@@ -1,7 +1,7 @@
-from src.base_agent import BaseAgent
+from google.adk import Agent
 
 
-class Advocate(BaseAgent):
+class Advocate(Agent):
     """倡議者代理類別
 
     角色任務：

--- a/src/agents/arbiter.py
+++ b/src/agents/arbiter.py
@@ -1,7 +1,7 @@
-from src.base_agent import BaseAgent
+from google.adk import Agent
 
 
-class Arbiter(BaseAgent):
+class Arbiter(Agent):
     """仲裁者代理類別
 
     角色任務：

--- a/src/agents/curator.py
+++ b/src/agents/curator.py
@@ -1,7 +1,7 @@
-from src.base_agent import BaseAgent
+from google.adk import Agent
 
 
-class Curator(BaseAgent):
+class Curator(Agent):
     """策展者代理類別
 
     角色任務：

--- a/src/agents/disrupter.py
+++ b/src/agents/disrupter.py
@@ -1,7 +1,7 @@
-from src.base_agent import BaseAgent
+from google.adk import Agent
 
 
-class Disrupter(BaseAgent):
+class Disrupter(Agent):
     """破壞者代理類別
 
     角色任務：

--- a/src/agents/masses.py
+++ b/src/agents/masses.py
@@ -1,7 +1,7 @@
-from src.base_agent import BaseAgent
+from google.adk import Agent
 
 
-class Masses(BaseAgent):
+class Masses(Agent):
     """群眾代理類別
 
     角色任務：

--- a/src/agents/skeptic.py
+++ b/src/agents/skeptic.py
@@ -1,7 +1,7 @@
-from src.base_agent import BaseAgent
+from google.adk import Agent
 
 
-class Skeptic(BaseAgent):
+class Skeptic(Agent):
     """懷疑者代理類別
 
     角色任務：


### PR DESCRIPTION
## Summary
- 所有代理改為繼承 `google.adk.Agent`
- 新增 Runner 範例，配置 Session、Memory 及事件監聽插件

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c31e64288323bd8b1670fa11c0b5