### PR TITLE
feat: add gemini llm client and runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,14 @@ Google 的 Agent Development Kit（ADK）提供工具整合、跨模型支援、
    ```
    - `adk run` 於終端機執行指定流程
    - `adk web` 啟動網頁介面以視覺化檢視事件
+
+## 使用範例
+1. 先設定 Gemini API 金鑰：
+   ```bash
+   export GEMINI_API_KEY="你的金鑰"
+   ```
+2. 執行範例 Runner：
+   ```bash
+   python runner.py
+   ```
+   程式會呼叫 `search_news` 工具並以 `gemini-2.0` 產生摘要，最終輸出包含生成式回覆與工具紀錄。

--- a/runner.py
+++ b/runner.py
@@ -1,66 +1,36 @@
-"""Runner 設定範例
+"""簡易 Runner，整合 LLM 回覆與工具結果"""
 
-此範例示範如何建立即時保留對話上下文與長期記憶的 Runner，
-並透過事件回呼監控工具調用與模型回覆。
-"""
+from __future__ import annotations
 
-from google.adk import Agent, Runner
-from google.adk.sessions import InMemorySessionService
-from google.adk.memory import InMemoryMemoryService
-from google.adk.events.event import Event
-from google.adk.plugins.base_plugin import BasePlugin
-from google.genai.types import Content, Part
+from dataclasses import dataclass
+from typing import Any
+
+from src.agents.llm_agent import LlmAgent
+from src.tools.search_news import search_news
 
 
-class EchoAgent(Agent):
-    """回聲代理，只回傳使用者輸入文字"""
+@dataclass
+class Runner:
+    """執行代理並收斂工具與模型輸出"""
 
-    def run(self, text: str) -> str:
-        """回傳相同內容，示範用"""
-        return f"回應：{text}"
+    agent: LlmAgent
 
+    def run(self, query: str) -> dict[str, Any]:
+        """執行單輪查詢並回傳整合結果"""
+        # 呼叫工具搜尋新聞
+        news = search_news(query)
+        self.agent.tool_logs.append({
+            "name": "search_news",
+            "input": {"keyword": query},
+            "output": news,
+        })
 
-class MonitorPlugin(BasePlugin):
-    """簡易事件監聽插件，用於後續監控或 Guardrail 擴充"""
-
-    async def on_event_callback(self, *, invocation_context, event: Event):
-        """監聽工具調用與模型回覆"""
-        # 檢查是否有工具被呼叫
-        for fn in event.get_function_calls():
-            print(f"工具呼叫：{fn.name}")
-
-        # 監控模型回覆（非使用者事件）
-        if event.author != "user":
-            print(f"模型回覆：{event.content}")
-
-        return None
+        # 生成式模型回覆
+        answer = self.agent.chat(f"請根據以下新聞提供摘要：{news}")
+        return {"reply": answer, "tools": self.agent.tool_logs}
 
 
-# 建立 Session 與 Memory 服務
-session_service = InMemorySessionService()
-memory_service = InMemoryMemoryService()
-
-
-# 建立 Runner，確保對話上下文與記憶保留
-runner = Runner(
-    app_name="agent-judge-demo",
-    agent=EchoAgent(name="echo", model="gemini-1.5-flash"),
-    session_service=session_service,
-    memory_service=memory_service,
-    plugins=[MonitorPlugin()],
-)
-
-
-async def demo() -> None:
-    """示範如何使用 Runner 進行一次對話"""
-
-    # 準備使用者訊息
-    message = Content(role="user", parts=[Part.from_text("你好")])
-
-    # 執行對話流程並處理事件
-    async for event in runner.run_async(
-        user_id="demo-user", session_id="demo-session", new_message=message
-    ):
-        # 此處可進一步處理事件，例如顯示或儲存
-        pass
-
+if __name__ == "__main__":
+    runner = Runner(LlmAgent(name="demo"))
+    result = runner.run("AI")
+    print(result)

--- a/src/agents/llm_agent.py
+++ b/src/agents/llm_agent.py
@@ -7,6 +7,7 @@ from typing import Any
 from google.adk.agents.llm_agent import LlmAgent as AdkLlmAgent
 from google.adk.tools import google_search
 
+from ..llm_client import LlmClient
 from ..tools.search_news import search_news
 
 
@@ -17,6 +18,7 @@ class LlmAgent(AdkLlmAgent):
         """初始化代理並註冊工具與回呼"""
         self.tool_logs: list[dict[str, Any]] = []
 
+        # 註冊預設工具
         tools = list(kwargs.pop("tools", []))
         tools.extend([google_search, search_news])
         kwargs["tools"] = tools
@@ -33,4 +35,11 @@ class LlmAgent(AdkLlmAgent):
         kwargs["before_tool_callback"] = _before_tool
         kwargs["after_tool_callback"] = _after_tool
 
+        # 建立 LLM 客戶端以支援多輪對話
+        self._llm = LlmClient()
+
         super().__init__(*args, **kwargs)
+
+    def chat(self, message: str) -> str:
+        """透過 LLM 客戶端產生回覆"""
+        return self._llm.generate(message)

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,0 +1,27 @@
+"""Gemini LLM 客戶端封裝"""
+
+from __future__ import annotations
+
+import google.generativeai as genai
+
+from .config import GEMINI_API_KEY
+
+
+class LlmClient:
+    """簡易的 Gemini 封裝，負責維護多輪對話"""
+
+    def __init__(self, model: str = "gemini-2.0") -> None:
+        """建立模型連線並設定 API 金鑰"""
+        if not GEMINI_API_KEY:
+            raise ValueError("未設定 GEMINI_API_KEY 環境變數")
+
+        # 於函式內設定金鑰，避免外洩
+        genai.configure(api_key=GEMINI_API_KEY)
+        self._model = genai.GenerativeModel(model)
+        # 使用 start_chat 以便保留對話歷史
+        self._chat = self._model.start_chat(history=[])
+
+    def generate(self, prompt: str) -> str:
+        """傳送提示並取得模型回覆"""
+        response = self._chat.send_message(prompt)
+        return response.text or ""


### PR DESCRIPTION
## Summary
- add Gemini client wrapper and manage API key
- use Gemini-backed chat in LlmAgent for multi-turn replies
- provide simple Runner that combines LLM answers with tool outputs and document usage

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a691a53250832385ab906f20d5dfc8