### PR TITLE
chore: add pytest dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 rouge-score
 pandas
 tabulate
+pytest>=8.2.0


### PR DESCRIPTION
## Summary
- include pytest>=8.2.0 in requirements so CI can run tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6b093360483238619e4635f1f67c2