### PR TITLE
feat: 允許注入自訂 LLM 客戶端

### DIFF
--- a/src/agents/llm_agent.py
+++ b/src/agents/llm_agent.py
@@ -17,18 +17,24 @@ class LlmAgent(AdkLlmAgent):
     """整合多項工具的 LLM 代理"""
 
     _tool_logs: list[dict[str, Any]] = PrivateAttr(default_factory=list)
+    _llm: LlmClient = PrivateAttr()
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        llm_client: LlmClient | None = None,
+        **kwargs,
+    ) -> None:
         """初始化代理並註冊工具與回呼"""
         # 註冊預設工具
         tools = list(kwargs.pop("tools", []))
         tools.extend([google_search, search_news])
         kwargs["tools"] = tools
 
-        # 建立 LLM 客戶端以支援多輪對話
-        self._llm = LlmClient()
-
         super().__init__(*args, **kwargs)
+
+        # 建立或使用傳入的 LLM 客戶端以支援多輪對話
+        self._llm = llm_client or LlmClient()
 
         before_tool, after_tool = create_tool_callbacks(self._tool_logs)
         self.before_tool_callback = before_tool

--- a/tests/test_agent_eval.py
+++ b/tests/test_agent_eval.py
@@ -16,11 +16,15 @@ from google.adk.evaluation.eval_metrics import EvalMetric, PrebuiltMetrics
 from google.genai.types import Content, FunctionCall, Part
 
 from src.agents.llm_agent import LlmAgent
+from src.llm_client import LlmClient
 from google.adk.tools import FunctionTool
 
 
-class _DummyLlm:
+class _DummyLlm(LlmClient):
     """回傳固定字串的假 LLM"""
+
+    def __init__(self) -> None:
+        pass
 
     def generate(self, prompt: str) -> str:
         return "測試回應"
@@ -36,8 +40,7 @@ class _TestAgent(LlmAgent):
 
     def __init__(self) -> None:
         tool = FunctionTool(_fake_search_news)
-        super().__init__(name="tester", tools=[tool])
-        self._llm = _DummyLlm()
+        super().__init__(name="tester", tools=[tool], llm_client=_DummyLlm())
 
 
 def test_response_and_tool_trajectory() -> None:


### PR DESCRIPTION
## Summary
- 在 `LlmAgent` 新增 `llm_client` 參數，可自訂或使用預設 `LlmClient`
- 測試代理 `_TestAgent` 透過新參數傳入 `_DummyLlm`，避免實際連線

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b0a09f188323b48b8aa629fadec1