### PR TITLE
加入辯論主持代理並重寫流程

### DIFF
--- a/src/agents/moderator.py
+++ b/src/agents/moderator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Set
+
+from google.adk import Agent
+from pydantic import PrivateAttr
+
+from .advocate import Advocate
+from .skeptic import Skeptic
+
+
+class Moderator(Agent):
+    """辯論主持代理類別
+
+    角色任務：
+        組織正反雙方進行辯論，負責初始陳述與後續質詢互動。
+    """
+
+    _advocate: Advocate = PrivateAttr()
+    _skeptic: Skeptic = PrivateAttr()
+
+    def __init__(self, name: str, advocate: Advocate, skeptic: Skeptic, **kwargs: Any) -> None:
+        super().__init__(name=name, **kwargs)
+        self._advocate = advocate
+        self._skeptic = skeptic
+
+    def _log(self, state: Dict[str, Any], speaker: str, message: str, seen: Set[str]) -> None:
+        """記錄對話並檢測重複內容"""
+        if message in seen:
+            state.setdefault("duplicates", []).append({"speaker": speaker, "message": message})
+        else:
+            seen.add(message)
+        state.setdefault("log", []).append({"speaker": speaker, "message": message})
+
+    def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """執行辯論流程
+
+        參數:
+            state (Dict[str, Any]): 需包含 `proposal` 的狀態字典。
+
+        回傳:
+            Dict[str, Any]: 更新後的狀態，包含 `log` 與 `duplicates`。
+        """
+        proposal = state.get("proposal", "")
+        seen: Set[str] = set()
+
+        # 正反方初次陳述
+        pro_opening = self._advocate.run(proposal)
+        self._log(state, self._advocate.name, pro_opening, seen)
+
+        con_opening = self._skeptic.run(proposal)
+        self._log(state, self._skeptic.name, con_opening, seen)
+
+        turn = "advocate"
+        for _ in range(3):
+            if turn == "advocate":
+                # 重申立場
+                stance = self._advocate.run(proposal)
+                self._log(state, self._advocate.name, stance, seen)
+                # 對手質疑
+                question = self._skeptic.run(stance)
+                self._log(state, self._skeptic.name, question, seen)
+                # 回答問題
+                answer = self._advocate.run(question)
+                self._log(state, self._advocate.name, answer, seen)
+                turn = "skeptic"
+            else:
+                stance = self._skeptic.run(proposal)
+                self._log(state, self._skeptic.name, stance, seen)
+                question = self._advocate.run(stance)
+                self._log(state, self._advocate.name, question, seen)
+                answer = self._skeptic.run(question)
+                self._log(state, self._skeptic.name, answer, seen)
+                turn = "advocate"
+
+        return state

--- a/src/workflows/pipeline.py
+++ b/src/workflows/pipeline.py
@@ -1,102 +1,32 @@
-"""多代理流程範例
+"""辯論流程建構模組
 
-此模組示範如何使用 `SequentialAgent` 與 `ParallelAgent` 組織
-多個子代理的執行順序與並行結果整合。
+此模組提供 `build_pipeline` 函式，建立以 `Moderator` 為核心的辯論系統。
 """
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Dict, Iterable, List, Tuple
-
 from ..agents.advocate import Advocate
 from ..agents.skeptic import Skeptic
-from ..agents.arbiter import Arbiter
-from ..agents.curator import Curator
-from ..agents.masses import Masses
+from ..agents.moderator import Moderator
 
 
-class SequentialAgent:
-    """簡易順序代理，依序執行多個步驟"""
+def build_pipeline() -> Moderator:
+    """建立辯論流程
 
-    def __init__(self, steps: Iterable[Callable[[Dict[str, Any]], Dict[str, Any]]]):
-        self.steps = list(steps)
-
-    def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        """依序將狀態傳遞給每個步驟"""
-        for step in self.steps:
-            state = step(state)
-        return state
-
-
-class ParallelAgent:
-    """簡易並行代理，允許不同子代理同時執行"""
-
-    def __init__(self, tasks: Iterable[Tuple[str, Callable[[Any], Any], str]]):
-        """建立並行任務列表
-
-        參數:
-            tasks: 由三元組組成的可迭代物件，內容為
-                `(輸出鍵, 代理實例, 輸入鍵)`
-        """
-        self.tasks = list(tasks)
-
-    def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
-        """同時執行所有子代理並整合結果"""
-        with ThreadPoolExecutor() as executor:
-            futures = {
-                executor.submit(agent.run, state[input_key]): output_key
-                for output_key, agent, input_key in self.tasks
-            }
-            return {futures[fut]: fut.result() for fut in futures}
-
-
-def build_pipeline() -> SequentialAgent:
-    """建立示範用的完整流程"""
-
+    回傳:
+        Moderator: 已配置正反雙方代理的主持人。
+    """
     advocate = Advocate(name="advocate", model="gemini-1.5-flash")
     skeptic = Skeptic(name="skeptic", model="gemini-1.5-flash")
-    arbiter = Arbiter(name="arbiter", model="gemini-1.5-flash")
-    curator = Curator(name="curator", model="gemini-1.5-flash")
-    masses = Masses(name="masses", model="gemini-1.5-flash")
-
-    parallel = ParallelAgent(
-        [
-            ("curated", curator, "materials"),
-            ("masses", masses, "question"),
-        ]
+    moderator = Moderator(
+        name="moderator", model="gemini-1.5-flash", advocate=advocate, skeptic=skeptic
     )
-
-    def step_advocate(state: Dict[str, Any]) -> Dict[str, Any]:
-        """執行倡議者"""
-        state["advocate"] = advocate.run(state["proposal"])
-        return state
-
-    def step_parallel(state: Dict[str, Any]) -> Dict[str, Any]:
-        """並行執行策展者與群眾"""
-        state.update(parallel.run(state))
-        return state
-
-    def step_skeptic(state: Dict[str, Any]) -> Dict[str, Any]:
-        """執行懷疑者"""
-        state["skeptic"] = skeptic.run(state["advocate"])
-        return state
-
-    def step_arbiter(state: Dict[str, Any]) -> Dict[str, Any]:
-        """綜合所有意見進行仲裁"""
-        opinions: List[str] = [state["advocate"], state["skeptic"], *state["masses"]]
-        state["arbiter"] = arbiter.run(opinions)
-        return state
-
-    return SequentialAgent([step_advocate, step_parallel, step_skeptic, step_arbiter])
+    return moderator
 
 
 if __name__ == "__main__":
     pipeline = build_pipeline()
-    initial_state = {
-        "proposal": "推廣太陽能發電",  # 初始提案
-        "materials": ["太陽能成本下降", "環保效益"],  # 策展素材
-        "question": "你支持推廣太陽能發電嗎？",  # 群眾問題
-    }
+    initial_state = {"proposal": "推廣太陽能發電"}
     final_state = pipeline.run(initial_state)
-    print(final_state["arbiter"])
+    for entry in final_state["log"]:
+        print(f"{entry['speaker']}：{entry['message']}")

--- a/tests/test_moderator_pipeline.py
+++ b/tests/test_moderator_pipeline.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.workflows.pipeline import build_pipeline
+
+
+def test_moderator_debate_flow() -> None:
+    """驗證主持人能夠管理完整辯論流程"""
+    moderator = build_pipeline()
+    state = {"proposal": "推廣太陽能發電"}
+    result = moderator.run(state)
+
+    assert "log" in result
+    assert len(result["log"]) == 11
+    assert "duplicates" in result
+    assert len(result["duplicates"]) > 0


### PR DESCRIPTION
## Summary
- 新增 Moderator 代理主持正反方辯論並記錄對話歷程
- 改寫 pipeline 以 Moderator 為入口，移除自訂序列/並行代理
- 增加測試涵蓋主持流程與重複內容檢測

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e5da79688323890db0834d738300