### PR TITLE
feat: extend debate agents from LlmAgent

### DIFF
--- a/src/agents/advocate.py
+++ b/src/agents/advocate.py
@@ -1,26 +1,53 @@
-from google.adk import Agent
+from __future__ import annotations
+
+"""倡議者代理，負責提出正面論述"""
+
+from typing import Iterable
+
+from .llm_agent import LlmAgent
 
 
-class Advocate(Agent):
-    """倡議者代理類別
+class Advocate(LlmAgent):
+    """倡議者代理類別"""
 
-    角色任務：
-        針對特定提案生成正面論述，說服受眾接受該提案。
+    def __init__(self, *args, context: str = "", **kwargs) -> None:
+        """初始化代理並接收主持者上下文"""
+        super().__init__(*args, **kwargs)
+        self._context = context
 
-    輸入資料格式：
-        `proposal` (`str`): 提案內容描述。
+    @property
+    def context(self) -> str:
+        """取得目前上下文"""
+        return self._context
 
-    輸出資料格式：
-        `str`: 支持該提案的倡議陳述。
-    """
+    def _merge_history(self, history: Iterable[str] | str) -> str:
+        """將對話紀錄統一為字串"""
+        if isinstance(history, str):
+            return history
+        return "\n".join(history)
 
-    def run(self, proposal: str) -> str:
-        """執行倡議流程
+    def _build_prompt(self, history: Iterable[str] | str, action: str, host_prompt: str | None) -> str:
+        """根據動作與主持者提示組合完整提示"""
+        if host_prompt is not None:
+            self._context = host_prompt
+        history_text = self._merge_history(history)
+        return f"{self._context}\n{action}\n{history_text}"
 
-        參數:
-            proposal (str): 需要倡議的提案內容。
+    def state_argument(self, history: Iterable[str] | str, host_prompt: str | None = None) -> str:
+        """針對提案提出正面論點"""
+        prompt = self._build_prompt(history, "請提出支持提案的論述。", host_prompt)
+        return self.chat(prompt)
 
-        回傳:
-            str: 結合正面論點後的倡議文字。
-        """
-        return f"我們應該推動{proposal}，它將帶來顯著的正面影響。"
+    def question_opponent(self, history: Iterable[str] | str, host_prompt: str | None = None) -> str:
+        """向對手提出質疑"""
+        prompt = self._build_prompt(history, "請向對手提出問題。", host_prompt)
+        return self.chat(prompt)
+
+    def answer_question(self, history: Iterable[str] | str, host_prompt: str | None = None) -> str:
+        """回答對方的提問"""
+        prompt = self._build_prompt(history, "請回答對方的問題。", host_prompt)
+        return self.chat(prompt)
+
+    def run(self, history: Iterable[str] | str) -> str:
+        """維持相容性的舊介面，等同於 state_argument"""
+        return self.state_argument(history)

--- a/tests/test_advocate_skeptic.py
+++ b/tests/test_advocate_skeptic.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""測試 Advocate 與 Skeptic 的對話功能"""
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("GEMINI_API_KEY", "dummy")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.agents.advocate import Advocate
+from src.agents.skeptic import Skeptic
+from src.llm_client import LlmClient
+
+
+class _EchoLlm(LlmClient):
+    """回傳提示內容的假 LLM"""
+
+    def __init__(self) -> None:  # pragma: no cover - 不需初始化
+        pass
+
+    def generate(self, prompt: str) -> str:  # pragma: no cover - 簡化回傳
+        return prompt
+
+
+def test_advocate_context_and_history() -> None:
+    """驗證倡議者能更新上下文並使用對話紀錄"""
+    llm = _EchoLlm()
+    advocate = Advocate(name="adv", model="dummy", llm_client=llm, context="初始提示")
+    first = advocate.state_argument(["提案 A"])
+    assert "初始提示" in first
+    second = advocate.state_argument("提案 B", host_prompt="新提示")
+    assert "新提示" in second and second != first
+
+
+def test_skeptic_methods() -> None:
+    """驗證懷疑者的方法與上下文更新"""
+    llm = _EchoLlm()
+    skeptic = Skeptic(name="sk", model="dummy", llm_client=llm, context="背景")
+    question = skeptic.question_opponent("主張")
+    assert "背景" in question
+    answer = skeptic.answer_question(["疑問"], host_prompt="更新背景")
+    assert "更新背景" in answer and answer != question


### PR DESCRIPTION
## Summary
- refactor Advocate and Skeptic to inherit LlmAgent and handle context-aware dialogue
- add conversation-driven tests for Advocate and Skeptic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e5e65e4c832385b293acd40ec654