### PR TITLE
feat: add historian agent

### DIFF
--- a/root_agent/agent.py
+++ b/root_agent/agent.py
@@ -6,7 +6,7 @@ from google.genai import types
 from google.adk.planners import BuiltInPlanner
 
 # === 匯入子代理 ===
-from .agents import curator_agent
+from .agents import curator_agent, historian_agent
 from .agents.moderator.loop import referee_loop          # LoopAgent（主持人回合制）
 from .agents.jury.agent import jury_agent
 from .agents.synthesizer.agent import synthesizer_agent
@@ -36,6 +36,7 @@ root_agent = SequentialAgent(
     name="root_pipeline",
     sub_agents=[
         curator_agent,
+        historian_agent,
         referee_loop,     # 這顆是 LoopAgent；會讀寫 state["debate_messages"]
         jury_agent,
         social_agent,

--- a/root_agent/agents/__init__.py
+++ b/root_agent/agents/__init__.py
@@ -4,6 +4,7 @@ Agents package: 聚合所有子代理
 
 from .advocate.agent import advocate_agent
 from .curator.agent import curator_agent
+from .historian.agent import historian_agent
 from .devil.agent import devil_agent
 from .jury.agent import jury_agent
 from .moderator.orchestrator import orchestrator_agent
@@ -15,6 +16,7 @@ from .social.agent import social_agent
 __all__ = [
     "advocate_agent",
     "curator_agent",
+    "historian_agent",
     "devil_agent",
     "jury_agent",
     "orchestrator_agent",

--- a/root_agent/agents/historian/__init__.py
+++ b/root_agent/agents/historian/__init__.py
@@ -1,0 +1,3 @@
+from .agent import historian_agent
+
+__all__ = ["historian_agent"]

--- a/root_agent/agents/historian/agent.py
+++ b/root_agent/agents/historian/agent.py
@@ -1,0 +1,39 @@
+from typing import List
+from pydantic import BaseModel, Field
+
+from google.adk.agents import LlmAgent, SequentialAgent
+from google.genai import types
+
+# ====== Schema 定義（輸出時間軸與宣傳模式）======
+class TimelineEvent(BaseModel):
+    date: str = Field(description="事件發生日期（ISO 8601 或文字描述）")
+    description: str = Field(description="事件概述")
+
+class PromotionPattern(BaseModel):
+    pattern: str = Field(description="宣傳或推廣模式")
+    comparison: str = Field(description="與時間軸事件的比對或證據")
+
+class HistorianOutput(BaseModel):
+    timeline: List[TimelineEvent]
+    promotion_patterns: List[PromotionPattern]
+
+# ====== Historian 核心代理 ======
+historian_llm_agent = LlmAgent(
+    name="historian_schema_agent",
+    model="gemini-2.5-flash",
+    instruction=(
+        "你是『歷史學者（Historian）』。\n"
+        "以下提供 Curator 的整理結果 JSON：{curation}\n"
+        "1) 根據資料建立重要事件時間軸。\n"
+        "2) 分析是否存在宣傳或推廣模式，並給出比對結果。\n"
+        "請僅輸出符合 HistorianOutput schema 的 JSON，不要額外文字。"
+    ),
+    output_schema=HistorianOutput,
+    output_key="history",
+    generate_content_config=types.GenerateContentConfig(temperature=0.2),
+)
+
+historian_agent = SequentialAgent(
+    name="historian",
+    sub_agents=[historian_llm_agent],
+)


### PR DESCRIPTION
## Summary
- 新增 historian 代理，根據整理結果輸出時間軸與宣傳模式分析
- 匯出並接入 root pipeline，於 curator 後辯論前產生歷史分析

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0101d9cd88323b2d9c44fcefd4c7b