### PR TITLE
為 social 與 jury 代理新增測試並上傳報告

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,10 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests
-        run: pytest
+        run: pytest --junitxml=test-results.xml
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report
+          path: test-results.xml

--- a/tests/test_social_jury.py
+++ b/tests/test_social_jury.py
@@ -1,0 +1,123 @@
+import sys, types, asyncio, importlib.util
+from pathlib import Path
+
+# 建立假模組以避免匯入真實的 Google ADK 與 GenAI
+fake_google = types.ModuleType("google")
+sys.modules.setdefault("google", fake_google)
+
+fake_adk = types.ModuleType("google.adk")
+sys.modules["google.adk"] = fake_adk
+fake_agents = types.ModuleType("google.adk.agents")
+fake_planners = types.ModuleType("google.adk.planners")
+sys.modules["google.adk.agents"] = fake_agents
+sys.modules["google.adk.planners"] = fake_planners
+
+fake_genai = types.ModuleType("google.genai")
+fake_genai_types = types.ModuleType("google.genai.types")
+sys.modules["google.genai"] = fake_genai
+sys.modules["google.genai.types"] = fake_genai_types
+fake_genai.types = fake_genai_types
+
+# ---- 假類別定義 ----
+class BaseAgent:
+    def __init__(self, name=None, sub_agents=None, output_key=None, **kwargs):
+        self.name = name
+        self.sub_agents = sub_agents or []
+        self.output_key = output_key
+
+    async def run_async(self, session):
+        pass
+
+class LlmAgent(BaseAgent):
+    pass
+
+class ParallelAgent(BaseAgent):
+    async def run_async(self, session):
+        for agent in self.sub_agents:
+            await agent.run_async(session)
+
+class SequentialAgent(BaseAgent):
+    async def run_async(self, session):
+        for agent in self.sub_agents:
+            await agent.run_async(session)
+
+class BuiltInPlanner:
+    pass
+
+class GenerateContentConfig:
+    def __init__(self, temperature=0.0):
+        self.temperature = temperature
+
+# 將假類別註冊到模組
+fake_agents.LlmAgent = LlmAgent
+fake_agents.ParallelAgent = ParallelAgent
+fake_agents.SequentialAgent = SequentialAgent
+fake_planners.BuiltInPlanner = BuiltInPlanner
+fake_genai_types.GenerateContentConfig = GenerateContentConfig
+
+# ---- 載入原始代理程式碼 ----
+ROOT = Path(__file__).resolve().parents[1]
+social_spec = importlib.util.spec_from_file_location(
+    "social_agent_module", ROOT / "root_agent/agents/social/agent.py"
+)
+social_mod = importlib.util.module_from_spec(social_spec)
+social_spec.loader.exec_module(social_mod)
+
+jury_spec = importlib.util.spec_from_file_location(
+    "jury_agent_module", ROOT / "root_agent/agents/jury/agent.py"
+)
+jury_mod = importlib.util.module_from_spec(jury_spec)
+jury_spec.loader.exec_module(jury_mod)
+
+# 簡單的 Session 物件
+class DummySession:
+    def __init__(self):
+        self.state = {}
+
+# ---- 測試 ----
+
+def test_social_agent_outputs_social_log():
+    """確認社群代理會在狀態中產出 social_log。"""
+
+    async def fake_parallel(session):
+        session.state["echo_chamber"] = "EC"
+        session.state["influencer"] = "INF"
+        session.state["disrupter"] = "DIS"
+
+    async def fake_aggregator(session):
+        log = social_mod.SocialLog(
+            echo_chamber=session.state["echo_chamber"],
+            influencer=session.state["influencer"],
+            disrupter=session.state["disrupter"],
+        )
+        session.state["social_log"] = log.model_dump()
+
+    social_mod._social_parallel.run_async = fake_parallel
+    social_mod._social_aggregator.run_async = fake_aggregator
+
+    session = DummySession()
+    asyncio.run(social_mod.social_agent.run_async(session))
+    assert "social_log" in session.state
+
+
+def test_jury_agent_consumes_social_log():
+    """確認陪審團代理會讀取 social_log 並產出分數。"""
+
+    async def fake_jury_run(session):
+        assert "social_log" in session.state
+        session.state["jury_result"] = {
+            "scores": {
+                "evidence_quality": 10,
+                "logical_rigor": 10,
+                "robustness": 10,
+                "social_impact": 10,
+                "total": 40,
+            }
+        }
+
+    jury_mod.jury_agent.run_async = fake_jury_run
+
+    session = DummySession()
+    session.state["social_log"] = {"echo_chamber": "EC"}
+    asyncio.run(jury_mod.jury_agent.run_async(session))
+    assert session.state["jury_result"]["scores"]["total"] == 40


### PR DESCRIPTION
## Summary
- 新增社群與陪審團代理的單元測試
- CI 執行 pytest 並上傳測試報告

## Testing
- `pytest --junitxml=test-results.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b01a928b348323bab473c49d729d7e