### PR TITLE
chore: add CD workflow generating report artifact

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,35 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: 生成報告
+    runs-on: ubuntu-latest
+    steps:
+      - name: 取得原始碼
+        uses: actions/checkout@v4
+      - name: 安裝 Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: 安裝依賴
+        run: pip install -r requirements.txt
+      - name: 執行示範報告
+        run: python -m root_agent.agent
+      - name: 上傳報告
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-report
+          path: outputs/*.md
+          if-no-files-found: error
+
+  deploy:
+    name: 部署
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ success() }}
+    steps:
+      - run: echo "部署完成（示意）"


### PR DESCRIPTION
## Summary
- add CD workflow that runs root agent on pushes to main and uploads report artifact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b02575d2608323b6568d24a61422f0