### PR TITLE
feat: integrate knowledge base for agent pipeline

### DIFF
--- a/root_agent/knowledge_base/__init__.py
+++ b/root_agent/knowledge_base/__init__.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+from typing import Any
+
+# 儲存圖片段（graphlet）到檔案系統
+# name 為圖片段名稱，data 為 JSON 可序列化資料
+# base_path 為基底資料夾路徑
+
+def _graphlet_path(base_path: str, name: str) -> Path:
+    """回傳指定圖片段的完整路徑"""
+    base = Path(base_path)
+    return base / f"{name}.json"
+
+
+def save_graphlet(name: str, data: Any, base_path: str) -> str:
+    """將圖片段資料寫入 JSON 檔並回傳路徑"""
+    path = _graphlet_path(base_path, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    return str(path)
+
+
+def load_graphlet(name: str, base_path: str) -> Any:
+    """讀取指定名稱的圖片段 JSON 資料"""
+    path = _graphlet_path(base_path, name)
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- add simple knowledge base module with save/load APIs
- persist curator and historian outputs to KB and reload for moderator/social agents
- inject KB path into session state during root run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b02909827c832389cc4f7fa6b5b13e