### PR TITLE
feat: unify evidence model across agents

### DIFF
--- a/root_agent/agents/__init__.py
+++ b/root_agent/agents/__init__.py
@@ -12,6 +12,7 @@ from .moderator.loop import referee_loop
 from .skeptic.agent import skeptic_agent
 from .synthesizer.agent import synthesizer_agent
 from .social.agent import social_agent
+from .evidence import Evidence
 
 __all__ = [
     "advocate_agent",
@@ -24,4 +25,5 @@ __all__ = [
     "skeptic_agent",
     "synthesizer_agent",
     "social_agent",
+    "Evidence",
 ]

--- a/root_agent/agents/advocate/agent.py
+++ b/root_agent/agents/advocate/agent.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import List
 from pydantic import BaseModel, Field
 
 from google.adk.agents import LlmAgent, SequentialAgent
 from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
+from ..evidence import Evidence
 
 
 # ---- 讀 Curator 的證據結構（最小鏡像；如你已有型別可改 from ... import） ----
@@ -20,16 +21,10 @@ class CuratorOutput(BaseModel):
 
 
 # ---- Advocate 輸出 Schema（ONLY JSON） ----
-class EvidenceUse(BaseModel):
-    title: str
-    url: str
-    why_relevant: str
-    quote_or_fact: Optional[str] = None  # 可選：引用片段或關鍵事實（簡短）
-
 class AdvocateOutput(BaseModel):
     thesis: str = Field(description="正方主張的核心命題（單句）")
     key_points: List[str] = Field(description="3~6 條支持重點，避免冗長")
-    evidence_used: List[EvidenceUse] = Field(description="逐條列出引用了哪些證據與理由")
+    evidence: List[Evidence] = Field(description="逐條列出引用的證據")
     caveats: List[str] = Field(description="已知限制或尚待查證處（1~3 條）")
 
 

--- a/root_agent/agents/curator/agent.py
+++ b/root_agent/agents/curator/agent.py
@@ -7,6 +7,7 @@ from google.genai import types
 
 # ✨ 內建搜尋工具
 from google.adk.tools.google_search_tool import GoogleSearchTool
+from ..evidence import Evidence
 
 
 # -------- Schema（輸入/輸出）---------
@@ -22,6 +23,24 @@ class SearchResult(BaseModel):
     title: str
     url: str
     snippet: str
+
+    def to_evidence(
+        self,
+        claim: str,
+        warrant: str,
+        method: Optional[str] = None,
+        risk: Optional[str] = None,
+        confidence: Optional[str] = None,
+    ) -> Evidence:
+        """轉為 Evidence 方便其他代理引用"""
+        return Evidence(
+            source=self.url,
+            claim=claim,
+            warrant=warrant,
+            method=method,
+            risk=risk,
+            confidence=confidence,
+        )
 
 class CuratorOutput(BaseModel):
     query: str

--- a/root_agent/agents/devil/agent.py
+++ b/root_agent/agents/devil/agent.py
@@ -1,13 +1,15 @@
-from typing import List, Optional
+from typing import List
 from pydantic import BaseModel, Field
 from google.adk.agents import LlmAgent, SequentialAgent
 from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
+from ..evidence import Evidence
 
 class DevilOutput(BaseModel):
     stance: str = Field(description="極端質疑的核心立場，單句")
     attack_points: List[str] = Field(description="2~5 條攻擊點，盡量尖銳")
+    evidence: List[Evidence] = Field(description="引用或質疑的證據列表")
     requested_clarifications: List[str] = Field(description="希望對方補充/舉證的關鍵問題")
 
 devil_tool_agent = LlmAgent(

--- a/root_agent/agents/evidence.py
+++ b/root_agent/agents/evidence.py
@@ -1,0 +1,29 @@
+from typing import Optional
+from pydantic import BaseModel
+
+
+class Evidence(BaseModel):
+    """通用證據資料模型"""
+    source: str  # 證據來源（如網址或文獻）
+    claim: str   # 證據支持的主張
+    warrant: str  # 為何此來源支持該主張
+    method: Optional[str] = None  # 取得或驗證證據的方法
+    risk: Optional[str] = None  # 可能的風險或偏誤
+    confidence: Optional[str] = None  # 對證據的信心程度
+
+
+# ---- Curator 轉 Evidence ----
+def curator_result_to_evidence(result, claim: str, warrant: str,
+                              method: Optional[str] = None,
+                              risk: Optional[str] = None,
+                              confidence: Optional[str] = None) -> Evidence:
+    """將 Curator 的搜尋結果轉為 Evidence"""
+    url = getattr(result, "url", "")
+    return Evidence(
+        source=url,
+        claim=claim,
+        warrant=warrant,
+        method=method,
+        risk=risk,
+        confidence=confidence,
+    )

--- a/root_agent/agents/skeptic/agent.py
+++ b/root_agent/agents/skeptic/agent.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import List
 from pydantic import BaseModel, Field
 
 from google.adk.agents import LlmAgent, SequentialAgent
 from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
+from ..evidence import Evidence
 
 
 # ---- 方便比對 Advocate / Curator 內容 ----
@@ -17,30 +18,18 @@ class CuratorOutput(BaseModel):
     query: str
     results: List[CuratorSearchResult]
 
-class EvidenceUse(BaseModel):
-    title: str
-    url: str
-    why_relevant: str
-    quote_or_fact: Optional[str] = None
-
 class AdvocateOutput(BaseModel):
     thesis: str
     key_points: List[str]
-    evidence_used: List[EvidenceUse]
+    evidence: List[Evidence]
     caveats: List[str]
 
 
 # ---- Skeptic 輸出 Schema（ONLY JSON） ----
-class CounterEvidence(BaseModel):
-    title: str
-    url: str
-    how_it_refutes: str
-    quote_or_fact: Optional[str] = None
-
 class SkepticOutput(BaseModel):
     counter_thesis: str = Field(description="反方的核心反命題（單句）")
     challenges: List[str] = Field(description="逐點質疑，最好對應正方 key_points 的編號或重點")
-    counter_evidence: List[CounterEvidence] = Field(description="反向或修正的證據")
+    evidence: List[Evidence] = Field(description="反向或修正的證據")
     open_questions: List[str] = Field(description="尚無定論、需要進一步查證的問題點")
 
 


### PR DESCRIPTION
## Summary
- add shared `Evidence` dataclass and helper to convert curator results
- adjust advocate, skeptic, and devil agents to emit `Evidence` arrays
- allow curator search results to convert into `Evidence`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03ffee9948323a6b138f43360274f