### PR TITLE
feat: add social metrics to social agent

### DIFF
--- a/root_agent/agents/social/agent.py
+++ b/root_agent/agents/social/agent.py
@@ -9,6 +9,9 @@ class SocialLog(BaseModel):
     echo_chamber: str = Field(description="各同溫層的反應摘要")
     influencer: str = Field(description="意見領袖如何放大或扭轉訊息")
     disrupter: str = Field(description="干擾者投放的訊息與系統反應")
+    polarization_index: float = Field(description="0 到 1 之間的極化指數")
+    virality_score: float = Field(description="0 到 1 之間的病毒式擴散分數")
+    manipulation_risk: float = Field(description="0 到 1 之間的操弄風險")
 
 
 # ==== 個別角色定義 ====
@@ -58,6 +61,8 @@ _social_aggregator = LlmAgent(
         "- Echo Chamber: {echo_chamber}\n"
         "- Influencer: {influencer}\n"
         "- Disrupter: {disrupter}\n"
+        "請根據上述內容計算以下指標：\n"
+        "polarization_index、virality_score、manipulation_risk，數值介於 0 到 1。\n"
         "僅輸出符合 SocialLog schema 的 JSON。"
     ),
     output_schema=SocialLog,

--- a/tests/test_social_jury.py
+++ b/tests/test_social_jury.py
@@ -89,6 +89,9 @@ def test_social_agent_outputs_social_log():
             echo_chamber=session.state["echo_chamber"],
             influencer=session.state["influencer"],
             disrupter=session.state["disrupter"],
+            polarization_index=0.1,
+            virality_score=0.2,
+            manipulation_risk=0.3,
         )
         session.state["social_log"] = log.model_dump()
 
@@ -98,6 +101,20 @@ def test_social_agent_outputs_social_log():
     session = DummySession()
     asyncio.run(social_mod.social_agent.run_async(session))
     assert "social_log" in session.state
+    log = session.state["social_log"]
+    # 確認新增的指標欄位存在且為浮點數
+    for key in [
+        "echo_chamber",
+        "influencer",
+        "disrupter",
+        "polarization_index",
+        "virality_score",
+        "manipulation_risk",
+    ]:
+        assert key in log
+    assert isinstance(log["polarization_index"], float)
+    assert isinstance(log["virality_score"], float)
+    assert isinstance(log["manipulation_risk"], float)
 
 
 def test_jury_agent_consumes_social_log():
@@ -118,6 +135,13 @@ def test_jury_agent_consumes_social_log():
     jury_mod.jury_agent.run_async = fake_jury_run
 
     session = DummySession()
-    session.state["social_log"] = {"echo_chamber": "EC"}
+    session.state["social_log"] = {
+        "echo_chamber": "EC",
+        "influencer": "INF",
+        "disrupter": "DIS",
+        "polarization_index": 0.1,
+        "virality_score": 0.2,
+        "manipulation_risk": 0.3,
+    }
     asyncio.run(jury_mod.jury_agent.run_async(session))
     assert session.state["jury_result"]["scores"]["total"] == 40


### PR DESCRIPTION
## Summary
- expand SocialLog schema with polarization_index, virality_score, and manipulation_risk metrics
- instruct social aggregator to compute new metrics
- update tests to check presence and type of new fields

## Testing
- `pytest tests/test_social_jury.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2fc7706fc8323b1dd742cf37a0766