### PR TITLE
feat: add truthfulness and consistency metrics

### DIFF
--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -1,19 +1,55 @@
 """評估指標函式"""
 from typing import List, Dict
+import json
+from urllib.request import urlopen
+from urllib.error import URLError
+from difflib import SequenceMatcher
+
+
+def _fetch_wikipedia_summary(topic: str) -> str:
+    """從維基百科取得條目摘要"""
+    url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{topic}"
+    try:
+        with urlopen(url, timeout=5) as resp:  # type: ignore[arg-type]
+            data = json.loads(resp.read().decode("utf-8"))
+            return data.get("extract", "")
+    except (URLError, ValueError):
+        return ""
 
 
 def evaluate_truthfulness(debate: List[Dict]) -> float:
-    """根據辯論訊息估算真實性分數"""
+    """根據辯論訊息與外部查證資料計算真實性"""
     if not debate:
         return 0.0
-    total = len(debate)
-    true_count = sum(1 for m in debate if "true" in m.get("content", "").lower())
-    return true_count / total
+
+    scores: List[float] = []
+    for msg in debate:
+        content = msg.get("content", "")
+        topic = msg.get("topic")
+        if not topic:
+            scores.append(0.0)
+            continue
+
+        # 取得外部查證內容並計算語意相似度
+        summary = _fetch_wikipedia_summary(topic)
+        ratio = SequenceMatcher(None, content.lower(), summary.lower()).ratio()
+        scores.append(ratio)
+
+    return sum(scores) / len(scores)
 
 
 def evaluate_consistency(debate: List[Dict]) -> float:
-    """根據辯論訊息估算一致性分數"""
+    """以訊息間語意相似度衡量辯論一致性"""
     if not debate:
         return 0.0
-    speakers = [m.get("role") for m in debate]
-    return 1.0 if len(set(speakers)) == 1 else 0.5
+
+    contents = [m.get("content", "") for m in debate]
+    if len(contents) == 1:
+        return 1.0
+
+    sims: List[float] = []
+    for a, b in zip(contents, contents[1:]):
+        ratio = SequenceMatcher(None, a.lower(), b.lower()).ratio()
+        sims.append(ratio)
+
+    return sum(sims) / len(sims)

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -1,18 +1,43 @@
 import sys
 from pathlib import Path
+from difflib import SequenceMatcher
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from evaluation import metrics
 from evaluation.metrics import evaluate_truthfulness, evaluate_consistency
 
 
-def test_metrics_return_scores():
-    """確保評估函式可以回傳分數"""
+def test_truthfulness_uses_external_data(monkeypatch):
+    """測試真實性評估與外部查證資料的整合"""
+    debate = [{"role": "pro", "content": "Earth orbits the Sun", "topic": "Earth"}]
+
+    def mock_fetch(topic: str) -> str:
+        assert topic == "Earth"
+        return "Earth orbits the Sun and is the third planet from the Sun."
+
+    monkeypatch.setattr(metrics, "_fetch_wikipedia_summary", mock_fetch)
+
+    score = evaluate_truthfulness(debate)
+    expected = SequenceMatcher(
+        None,
+        debate[0]["content"].lower(),
+        mock_fetch("Earth").lower(),
+    ).ratio()
+    assert score == expected
+
+
+def test_consistency_similarity():
+    """測試訊息語意相似度的一致性評估"""
     debate = [
-        {"role": "pro", "content": "This is true."},
-        {"role": "con", "content": "This is false."},
+        {"role": "pro", "content": "Cats are animals."},
+        {"role": "con", "content": "Cats are animals indeed."},
+        {"role": "judge", "content": "Dogs are unrelated."},
     ]
-    truth = evaluate_truthfulness(debate)
-    consistency = evaluate_consistency(debate)
-    assert truth == 0.5
-    assert consistency == 0.5
+
+    score = evaluate_consistency(debate)
+    s1 = SequenceMatcher(None, debate[0]["content"].lower(), debate[1]["content"].lower()).ratio()
+    s2 = SequenceMatcher(None, debate[1]["content"].lower(), debate[2]["content"].lower()).ratio()
+    expected = (s1 + s2) / 2
+    assert score == expected
+


### PR DESCRIPTION
## Summary
- integrate Wikipedia-based fact check for truthfulness scoring
- compute debate consistency via pairwise semantic similarity
- add tests for new metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b30622f0388323a7b14f87d5d2a26a