### PR TITLE
refactor moderator stop signal

### DIFF
--- a/root_agent/agents/moderator/orchestrator.py
+++ b/root_agent/agents/moderator/orchestrator.py
@@ -13,6 +13,9 @@ from root_agent.agents.advocate.agent import advocate_agent
 from root_agent.agents.skeptic.agent import skeptic_agent
 from root_agent.agents.devil.agent import devil_agent
 
+# 統一設定停用訊號的工具
+from .stop_utils import mark_stop
+
 # 把子代理包成可被呼叫的工具（a2a / a3a）
 advocate_tool = AgentTool(advocate_agent)
 advocate_tool.name = "call_advocate"
@@ -30,9 +33,8 @@ def _exit_if_end(callback_context, **_):
     if next_speaker is None and isinstance(decision, dict):
         next_speaker = decision.get("next_speaker")
     if next_speaker == "end":
-        # 標記停用信號，由統一的 stop_enforcer 來觸發實際的工具呼叫
-        state["stop_signal"] = "exit_loop"
-        return types.Content(parts=[types.Part.from_text(text="exit_loop")])
+        # 若決策為結束，統一由工具標記停用訊號
+        return mark_stop(state)
     return None
 
 class NextTurnDecision(BaseModel):

--- a/root_agent/agents/moderator/stop_utils.py
+++ b/root_agent/agents/moderator/stop_utils.py
@@ -1,0 +1,7 @@
+from google.genai import types
+
+
+def mark_stop(state):
+    """標記需要停止並回傳統一訊號"""
+    state["stop_signal"] = "exit_loop"
+    return types.Content(parts=[types.Part.from_text(text="exit_loop")])


### PR DESCRIPTION
## Summary
- centralize stop signaling logic with reusable `mark_stop`
- simplify moderator loop and orchestrator callbacks using unified stop helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b45034b1d8832390c4bcb8e6343d4e