### PR TITLE
fix: disable transfers for schema agents

### DIFF
--- a/root_agent/agents/advocate/agent.py
+++ b/root_agent/agents/advocate/agent.py
@@ -52,6 +52,9 @@ advocate_schema_agent = LlmAgent(
     ),
     # no tools here
     output_schema=AdvocateOutput,
+    # 設為禁止傳遞以符合 output_schema 限制
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="advocacy",
     # planner removed to avoid sending thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.4),

--- a/root_agent/agents/curator/agent.py
+++ b/root_agent/agents/curator/agent.py
@@ -75,6 +75,9 @@ curator_schema_agent = LlmAgent(
     # no tools here
     input_schema=CuratorInput,
     output_schema=CuratorOutput,
+    # 禁止輸出傳遞以避免與 schema 衝突
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="curation",
     # planner removed to avoid sending thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.4),

--- a/root_agent/agents/devil/agent.py
+++ b/root_agent/agents/devil/agent.py
@@ -35,6 +35,9 @@ devil_schema_agent = LlmAgent(
     ),
     # no tools here
     output_schema=DevilOutput,
+    # 禁止向父層或同儕傳遞輸出
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="devil_turn",
     # planner removed to avoid sending unsupported thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.0),

--- a/root_agent/agents/historian/agent.py
+++ b/root_agent/agents/historian/agent.py
@@ -29,6 +29,9 @@ historian_llm_agent = LlmAgent(
         "請僅輸出符合 HistorianOutput schema 的 JSON，不要額外文字。"
     ),
     output_schema=HistorianOutput,
+    # 禁止向其他代理傳輸結果
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="history",
     generate_content_config=types.GenerateContentConfig(temperature=0.2),
 )

--- a/root_agent/agents/jury/agent.py
+++ b/root_agent/agents/jury/agent.py
@@ -45,6 +45,9 @@ jury_agent = LlmAgent(
         "嚴格輸出 JSON，必須符合 JuryOutput schema；不要多餘文字。"
     ),
     output_schema=JuryOutput,
+    # 禁止輸出傳遞，避免 schema 衝突
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="jury_result",
     # planner removed to avoid sending thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.0),

--- a/root_agent/agents/moderator/agent.py
+++ b/root_agent/agents/moderator/agent.py
@@ -100,6 +100,9 @@ decision_agent = LlmAgent(
     ),
     # no tools
     output_schema=NextTurnDecision,
+    # 禁止向父層或同儕傳遞以符合 schema 限制
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="next_decision",
     # planner removed to avoid sending thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.0),

--- a/root_agent/agents/skeptic/agent.py
+++ b/root_agent/agents/skeptic/agent.py
@@ -58,6 +58,9 @@ skeptic_schema_agent = LlmAgent(
     ),
     # 無需工具
     output_schema=SkepticOutput,
+    # output_schema 與 transfer 不相容，需禁止傳遞
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="skepticism",
     generate_content_config=types.GenerateContentConfig(temperature=0.0),
 )

--- a/root_agent/agents/social/agent.py
+++ b/root_agent/agents/social/agent.py
@@ -66,6 +66,9 @@ _social_aggregator = LlmAgent(
         "僅輸出符合 SocialLog schema 的 JSON。"
     ),
     output_schema=SocialLog,
+    # 禁止傳遞以符合 output_schema 規定
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="social_log",
 )
 

--- a/root_agent/agents/synthesizer/agent.py
+++ b/root_agent/agents/synthesizer/agent.py
@@ -56,6 +56,9 @@ synthesizer_agent = LlmAgent(
         "5) appendix_links 可放『辯論日誌』或外部來源列表連結（若有）。"
     ),
     output_schema=FinalReport,
+    # 禁止傳遞以避免 output_schema 衝突
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
     output_key="final_report_json",
     # planner removed to avoid sending thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.0),


### PR DESCRIPTION
## Summary
- prevent agent output transfer when using `output_schema` to eliminate runtime warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5357f69608323a8f70f37ff3f0001