### PR TITLE
feat: 加入社群噪音注入機制

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -64,8 +64,10 @@ flowchart LR
       EC((Echo Chamber))
       INF((Influencer))
       DIS[Disrupter]
+      SN[(state["social_noise"])]
       EC -- 放大 --> INF
       DIS -- 注入假訊息 --> EC
+      DIS -->|噪音寫入| SN
     end
   end
   subgraph III[階段三：裁決與整合]
@@ -115,6 +117,15 @@ flowchart LR
   - `PolarizationIndex`（群際距離/群內方差）、
   - `ViralityScore`（基本傳染數 R₀ 類比）、
   - `ManipulationRisk`（易受操弄度）。
+
+### Social Noise 噪音注入
+```mermaid
+flowchart LR
+  EC(EchoChamber) --> INF(Influencer) --> DIS(Disrupter)
+  DIS --> EC
+  DIS --> SN[(state["social_noise"])]
+```
+EchoChamber 先呈現各社群群組的回應，Influencer 依此放大或扭轉訊息，Disrupter 再根據風向注入最易擴散的噪音。該噪音會即時寫入 `state["social_noise"]`，供裁決層評估傳播風險與後續策略。
 
 ---
 
@@ -216,9 +227,11 @@ for round in range(MAX_ROUNDS):
     if stop_condition(DebateLog):
         break
 
-SocialLog.simulate(EchoChamber, Influencer, Disrupter)
-score = Jury.score(DebateLog, SocialLog)
-report = Synthesizer.write(DebateLog, SocialLog, score)
+social_noise = Disrupter.inject(EchoChamber)
+state["social_noise"] = social_noise
+social_log = SocialLog.simulate(EchoChamber, Influencer, social_noise)
+score = Jury.score(DebateLog, social_log)
+report = Synthesizer.write(DebateLog, social_log, score)
 ```
 
 ---

--- a/root_agent/agents/social/agent.py
+++ b/root_agent/agents/social/agent.py
@@ -36,14 +36,15 @@ _influencer_agent = LlmAgent(
     output_key="influencer",
 )
 
-# Disrupter：注入干擾訊息以測試傳播韌性
+# Disrupter：注入干擾訊息以測試傳播韌性，並將噪音寫入 state["social_noise"]
 _disrupter_agent = LlmAgent(
     name="disrupter",
     model="gemini-2.5-flash",
     instruction=(
         "你是 Disrupter，注入干擾訊息來測試傳播的韌性。"
     ),
-    output_key="disrupter",
+    # 將原始噪音內容寫入 state["social_noise"]
+    output_key="social_noise",
 )
 
 # 平行模擬三種角色
@@ -60,7 +61,7 @@ _social_aggregator = LlmAgent(
         "你是社群紀錄者，請依序讀取以下輸出並統整成 JSON。\n"
         "- Echo Chamber: {echo_chamber}\n"
         "- Influencer: {influencer}\n"
-        "- Disrupter: {disrupter}\n"
+        "- Disrupter: {social_noise}\n"
         "請根據上述內容計算以下指標：\n"
         "polarization_index、virality_score、manipulation_risk，數值介於 0 到 1。\n"
         "僅輸出符合 SocialLog schema 的 JSON。"


### PR DESCRIPTION
## Summary
- 繪製社群噪音注入流程圖，說明 EchoChamber → Influencer → Disrupter 互動並寫入 `state["social_noise"]`
- Social agent 將 Disrupter 的輸出同步存入 `state["social_noise"]`
- 更新架構概覽與 pseudo code，納入噪音紀錄

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7b385f08323a0accbf35c192b1d