### PR TITLE
feat: escalate when debate ends

### DIFF
--- a/root_agent/agents/moderator/agent.py
+++ b/root_agent/agents/moderator/agent.py
@@ -77,8 +77,10 @@ def _exit_if_end(callback_context, **_):
     if next_speaker is None and isinstance(decision, dict):
         next_speaker = decision.get("next_speaker")
     if next_speaker == "end":
-        # 若決策為結束，統一由工具標記停用訊號
-        return mark_stop(state)
+        # 若決策為結束，統一由工具標記停用訊號並讓 LoopAgent 立即退出
+        result = mark_stop(state)
+        callback_context.actions.escalate = True  # 標記需往上冒泡停止迴圈
+        return result
     return None
 
 class NextTurnDecision(BaseModel):


### PR DESCRIPTION
## Summary
- escalate stop action in moderator's `_exit_if_end` callback

## Testing
- `pytest -q`
- `python - <<'PY'
from types import SimpleNamespace
from root_agent.agents.moderator.agent import _exit_if_end
class Ctx:
    def __init__(self):
        self.state={'next_decision':{'next_speaker':'end'}}
        self.actions=SimpleNamespace(escalate=False)
ctx=Ctx()
res=_exit_if_end(ctx)
print('stop_signal:', ctx.state['stop_signal'])
print('escalate:', ctx.actions.escalate)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7a8de3c8323bc49a12794081399