### PR TITLE
feat: simulate social noise before moderation

### DIFF
--- a/root_agent/agent.py
+++ b/root_agent/agent.py
@@ -3,9 +3,8 @@ from google.adk.agents import SequentialAgent
 from root_agent.tools import initialize_debate_log
 
 # === 匯入子代理 ===
-from root_agent.agents import curator_agent, historian_agent
+from root_agent.agents import curator_agent, historian_agent, social_summary_agent
 from root_agent.agents.moderator.agent import referee_loop
-from root_agent.agents.social.agent import social_agent
 from root_agent.agents.jury.agent import jury_agent
 from root_agent.agents.synthesizer.agent import synthesizer_agent
 
@@ -43,7 +42,7 @@ root_agent = SequentialAgent(
         curator_agent,
         historian_agent,  # 歷史學者：整理時間軸與宣傳模式
         referee_loop,     # 這顆是 LoopAgent；會讀寫 state["debate_messages"]
-        social_agent,
+        social_summary_agent,
         jury_agent,
         synthesizer_agent # 產生 state["final_report_json"]
     ],

--- a/root_agent/agents/__init__.py
+++ b/root_agent/agents/__init__.py
@@ -10,7 +10,8 @@ from .jury.agent import jury_agent
 from .moderator.agent import orchestrator_agent, referee_loop
 from .skeptic.agent import skeptic_agent
 from .synthesizer.agent import synthesizer_agent
-from .social.agent import social_agent
+from .social.agent import social_summary_agent
+from .social_noise.agent import social_noise_agent
 
 __all__ = [
     "advocate_agent",
@@ -22,5 +23,6 @@ __all__ = [
     "referee_loop",
     "skeptic_agent",
     "synthesizer_agent",
-    "social_agent",
+    "social_summary_agent",
+    "social_noise_agent",
 ]

--- a/root_agent/agents/moderator/agent.py
+++ b/root_agent/agents/moderator/agent.py
@@ -12,6 +12,7 @@ from root_agent.tools import Turn, append_turn, initialize_debate_log
 from root_agent.agents.advocate.agent import advocate_agent
 from root_agent.agents.skeptic.agent import skeptic_agent
 from root_agent.agents.devil.agent import devil_agent
+from root_agent.agents.social_noise.agent import social_noise_agent
 
 # 統一設定停用訊號的工具
 from .tools import mark_stop, exit_loop, deterministic_stop_callback
@@ -94,7 +95,7 @@ decision_agent = LlmAgent(
     instruction=(
         "你是主持人的決策模組。目標：在維持秩序、避免重複論點、推進爭點澄清的前提下，"
         "輸出一個 NextTurnDecision JSON（next_speaker: 'advocate'|'skeptic'|'devil'|'end'）以及簡短 rationale。\n"
-        "輸入：\n- CURATION: {curation}\n- MESSAGES(JSON array): (the current debate messages stored in state['debate_messages'])\n\n"
+        "輸入：\n- CURATION: {curation}\n- SOCIAL_NOISE: {social_noise}\n- MESSAGES(JSON array): (the current debate messages stored in state['debate_messages'])\n\n"
         "僅產生 NextTurnDecision，不呼叫任何工具。"
     ),
     # no tools
@@ -156,6 +157,6 @@ stop_checker = LlmAgent(
 # ---- referee loop (LoopAgent) ----
 referee_loop = LoopAgent(
     name="debate_referee_loop",
-    sub_agents=[orchestrator_agent, stop_checker],
+    sub_agents=[social_noise_agent, orchestrator_agent, stop_checker],
     max_iterations=12,
 )

--- a/root_agent/agents/social/__init__.py
+++ b/root_agent/agents/social/__init__.py
@@ -1,5 +1,5 @@
 """Social 模組：模擬社群擴散"""
 
-from .agent import social_agent
+from .agent import social_summary_agent
 
-__all__ = ["social_agent"]
+__all__ = ["social_summary_agent"]

--- a/root_agent/agents/social/agent.py
+++ b/root_agent/agents/social/agent.py
@@ -72,8 +72,8 @@ _social_aggregator = LlmAgent(
     output_key="social_log",
 )
 
-# 公開的 social_agent，先平行模擬，再聚合結果
-social_agent = SequentialAgent(
-    name="social",
+# 公開的 social_summary_agent，先平行模擬，再聚合結果
+social_summary_agent = SequentialAgent(
+    name="social_summary",
     sub_agents=[_social_parallel, _social_aggregator],
 )

--- a/root_agent/agents/social_noise/__init__.py
+++ b/root_agent/agents/social_noise/__init__.py
@@ -1,0 +1,5 @@
+"""Social Noise 模組：模擬社群噪音"""
+
+from .agent import social_noise_agent
+
+__all__ = ["social_noise_agent"]

--- a/root_agent/agents/social_noise/agent.py
+++ b/root_agent/agents/social_noise/agent.py
@@ -1,0 +1,70 @@
+from pydantic import BaseModel, Field
+
+from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
+
+
+# ==== 社群噪音紀錄 Schema ====
+class NoiseLog(BaseModel):
+    """社群噪音紀錄"""
+    echo_chamber: str = Field(description="各同溫層的反應摘要")
+    influencers: list[str] = Field(description="各意見領袖的放大或扭轉訊息")
+    disrupter: str = Field(description="干擾者投放的訊息與系統反應")
+
+
+# ==== 個別角色定義 ====
+# Echo Chamber：模擬不同社群群組的反應
+_echo_agent = LlmAgent(
+    name="echo_chamber",
+    model="gemini-2.5-flash",
+    instruction="你是 Echo Chamber，模擬多個社群群組對當前議題的即時反應。",
+    output_key="echo_chamber",
+)
+
+# Influencer：可有多位意見領袖
+_influencer_agents = [
+    LlmAgent(
+        name=f"influencer_{i}",
+        model="gemini-2.5-flash",
+        instruction="你是 Influencer，根據 Echo Chamber 的反應放大或扭轉訊息。",
+        output_key=f"influencer_{i}",
+    )
+    for i in range(1, 3)
+]
+
+# Disrupter：注入干擾訊息
+_disrupter_agent = LlmAgent(
+    name="disrupter",
+    model="gemini-2.5-flash",
+    instruction="你是 Disrupter，注入干擾訊息來測試傳播的韌性。",
+    output_key="disrupter",
+)
+
+# 平行執行三類角色
+_social_noise_parallel = ParallelAgent(
+    name="social_noise_parallel",
+    sub_agents=[_echo_agent, *_influencer_agents, _disrupter_agent],
+)
+
+# 聚合社群噪音輸出為 NoiseLog JSON
+_noise_aggregator = LlmAgent(
+    name="noise_aggregator",
+    model="gemini-2.5-flash",
+    instruction=(
+        "你是社群噪音紀錄者，請依序讀取以下輸出並統整成 JSON。\n"
+        "- Echo Chamber: {echo_chamber}\n"
+        "- Influencer 1: {influencer_1}\n"
+        "- Influencer 2: {influencer_2}\n"
+        "- Disrupter: {disrupter}\n"
+        "僅輸出符合 NoiseLog schema 的 JSON。"
+    ),
+    output_schema=NoiseLog,
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
+    output_key="social_noise",
+)
+
+# 公開的 social_noise_agent，先平行模擬，再聚合結果
+social_noise_agent = SequentialAgent(
+    name="social_noise",
+    sub_agents=[_social_noise_parallel, _noise_aggregator],
+)


### PR DESCRIPTION
## Summary
- add social_noise agent that parallelizes EchoChamber, multiple Influencers, and a Disrupter into a NoiseLog
- feed social_noise into moderator decision and loop before orchestrator
- rename debate social agent to social_summary_agent and update pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e7ae3fec8323ae37cba63317f0be