### PR TITLE
修正 architecture.md 的 Mermaid 標籤

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -64,7 +64,7 @@ flowchart LR
       EC((Echo Chamber))
       INF((Influencer))
       DIS[Disrupter]
-      SN[(state["social_noise"])]
+      SN["state['social_noise']"]
       EC -- 放大 --> INF
       DIS -- 注入假訊息 --> EC
       DIS -->|噪音寫入| SN
@@ -126,7 +126,7 @@ flowchart LR
 flowchart LR
   EC(EchoChamber) --> INF(Influencer) --> DIS(Disrupter)
   DIS --> EC
-  DIS --> SN[(state["social_noise"])]
+  DIS --> SN["state['social_noise']"]
 ```
 EchoChamber 先呈現各社群群組的回應，Influencer 依此放大或扭轉訊息，Disrupter 再根據風向注入最易擴散的噪音。該噪音會即時寫入 `state["social_noise"]`，供裁決層評估傳播風險與後續策略。
 


### PR DESCRIPTION
## 摘要
- 修正 Architecture Overview 與 Social Noise 子圖中無效的 `social_noise` 標籤，改為 Mermaid 可解析格式

## 測試
- `pytest`
- `npx -y @mermaid-js/mermaid-cli -i /tmp/diagram.mmd -o /tmp/diagram.svg` *(缺少系統函式庫 `libXdamage.so.1`，無法預覽)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bf8e26188323aea61ad1f2269ad3