### PR TITLE
feat: add evidence checker agent

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -31,6 +31,7 @@
 - **The Disrupter｜謠言製造者**：依社群情緒注入最易擴散的干擾訊息（文字/影像），用於壓力測試。
 
 ### 2.4 裁決與整合層（Synthesis & Judgment Layer）
+- **The Evidence Checker｜證據查核者**：串接 Google Search Tool 逐句查證主張並輸出證據鍊。
 - **The Jury｜陪審團**：依「證據品質、邏輯嚴謹、論證韌性、社會影響」四維打分。
 - **The Synthesizer｜知識整合者**：彙整辯論與傳播數據，產出報告與行動建議。
 
@@ -70,23 +71,25 @@ flowchart LR
       DIS -->|噪音寫入| SN
     end
   end
+  SN --> M
   subgraph III[階段三：裁決與整合]
     DL[(Debate Log)]
     SL[(Social Log)]
+    EA{Evidence Agent}
+    ECHK{Evidence Check}
     J{Jury}
     SY{Synthesizer}
-    DL --> J & SY
+    DL --> J & EA
+    EA --> ECHK --> SY
     SL --> J & SY
     J -- 多維評分 --> SY
   end
   INF --> SL
   subgraph IV[階段四：最終產出]
-    EV[(Evidence)]
-    ECHK{Evidence Check}
     RPT[[深度分析報告]]
   end
+  SY --> RPT
   KB --> M & EC
-  SY --> EV --> ECHK --> RPT
 ```
 
 ---
@@ -233,8 +236,10 @@ for round in range(MAX_ROUNDS):
 social_noise = Disrupter.inject(EchoChamber)
 state["social_noise"] = social_noise
 social_log = SocialLog.simulate(EchoChamber, Influencer, social_noise)
-score = Jury.score(DebateLog, social_log)
-report = Synthesizer.write(DebateLog, social_log, score)
+evidence = EvidenceAgent.verify(DebateLog)
+checked = EvidenceCheck.run(evidence)
+score = Jury.score(DebateLog, social_log, checked)
+report = Synthesizer.write(DebateLog, social_log, checked, score)
 ```
 
 ---

--- a/root_agent/agent.py
+++ b/root_agent/agent.py
@@ -1,15 +1,19 @@
 from google.adk.agents import SequentialAgent
-
 from root_agent.tools import initialize_debate_log
 
 # === 匯入子代理 ===
-from root_agent.agents import curator_agent, historian_agent, social_summary_agent
+from root_agent.agents import (
+    curator_agent,
+    historian_agent,
+    social_summary_agent,
+    evidence_agent,
+)
 from root_agent.agents.moderator.agent import referee_loop
 from root_agent.agents.jury.agent import jury_agent
 from root_agent.agents.synthesizer.agent import synthesizer_agent
 
 # =============== Root Pipeline ===============
-# 固定順序：Curator → Historian → 主持人回合制（正/反/極端）→ Social → Jury → Synthesizer(JSON)
+# 固定順序：Curator → Historian → 主持人回合制（正/反/極端）→ Social → Evidence → Jury → Synthesizer(JSON)
 from google.adk.agents import LlmAgent
 
 
@@ -43,6 +47,7 @@ root_agent = SequentialAgent(
         historian_agent,  # 歷史學者：整理時間軸與宣傳模式
         referee_loop,     # 這顆是 LoopAgent；會讀寫 state["debate_messages"]
         social_summary_agent,
+        evidence_agent,
         jury_agent,
         synthesizer_agent # 產生 state["final_report_json"]
     ],

--- a/root_agent/agents/__init__.py
+++ b/root_agent/agents/__init__.py
@@ -12,6 +12,7 @@ from .skeptic.agent import skeptic_agent
 from .synthesizer.agent import synthesizer_agent
 from .social.agent import social_summary_agent
 from .social_noise.agent import social_noise_agent
+from .evidence.agent import evidence_agent
 
 __all__ = [
     "advocate_agent",
@@ -25,4 +26,5 @@ __all__ = [
     "synthesizer_agent",
     "social_summary_agent",
     "social_noise_agent",
+    "evidence_agent",
 ]

--- a/root_agent/agents/evidence/__init__.py
+++ b/root_agent/agents/evidence/__init__.py
@@ -1,0 +1,3 @@
+from .agent import evidence_agent
+
+__all__ = ["evidence_agent"]

--- a/root_agent/agents/evidence/agent.py
+++ b/root_agent/agents/evidence/agent.py
@@ -1,0 +1,55 @@
+from typing import List
+from pydantic import BaseModel, Field
+
+from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.tools.google_search_tool import GoogleSearchTool
+from google.genai import types
+
+from root_agent.tools.evidence import Evidence
+
+
+# ==== 查核結果資料模型 ====
+class CheckedClaim(BaseModel):
+    """單一句子與其證據鍊"""
+    claim: str = Field(description="待查證的命題")
+    evidences: List[Evidence] = Field(description="對應的證據鍊列表")
+
+
+class EvidenceCheckOutput(BaseModel):
+    """多條命題的查核結果"""
+    checked_claims: List[CheckedClaim] = Field(description="查核後的命題與證據鍊")
+
+
+# Step 1: 使用 Google 搜尋補齊證據
+_evidence_tool_agent = LlmAgent(
+    name="evidence_tool_runner",
+    model="gemini-2.5-flash",
+    instruction=(
+        "根據辯論紀錄 state['debate_messages'] 或辯論檔案，"
+        "使用 GoogleSearchTool 逐條查證並將搜尋結果寫入 state['evidence_raw']。"
+    ),
+    tools=[GoogleSearchTool()],
+    output_key="evidence_raw",
+)
+
+
+# Step 2: 轉為結構化證據鍊 JSON
+_evidence_schema_agent = LlmAgent(
+    name="evidence_schema_validator",
+    model="gemini-2.5-flash",
+    instruction=(
+        "請整理 state['evidence_raw']，輸出符合 EvidenceCheckOutput 的 JSON。"
+    ),
+    output_schema=EvidenceCheckOutput,
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
+    output_key="evidence_checked",
+    generate_content_config=types.GenerateContentConfig(temperature=0.0),
+)
+
+
+# 公開的 Evidence Agent，先查詢再整理
+evidence_agent = SequentialAgent(
+    name="evidence_agent",
+    sub_agents=[_evidence_tool_agent, _evidence_schema_agent],
+)


### PR DESCRIPTION
## Summary
- introduce evidence checker agent using Google Search for claim verification
- document new agent and social-noise input in architecture diagram and flow
- wire evidence agent into root pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca4a54e48323a45839338ee9ff55