### PR TITLE
初始化 Session state 並移除 setdefault 使用

### DIFF
--- a/judge/agents/devil/agent.py
+++ b/judge/agents/devil/agent.py
@@ -47,13 +47,6 @@ devil_schema_agent = LlmAgent(
 )
 
 
-# Combined pipeline
-devil_agent = SequentialAgent(
-    name="devils_advocate",
-    sub_agents=[devil_tool_agent, devil_schema_agent],
-)
-
-
 def _record_devil(agent_context=None, **_):
     if agent_context is None:
         return None
@@ -66,13 +59,18 @@ def _record_devil(agent_context=None, **_):
         )
     )
 
-devil_agent.after_agent_callback = _record_devil
+
+# 保留前置處理介面，目前無需額外動作
+def _before_devil(agent_context=None, **_):
+    return None
 
 
-# ensure debate_messages exists before running devil agent
-def _ensure_debate_messages(agent_context=None, **_):
-    if agent_context is None:
-        return None
-    agent_context.state.setdefault("debate_messages", [])
+# Combined pipeline
+devil_agent = SequentialAgent(
+    name="devils_advocate",
+    sub_agents=[devil_tool_agent, devil_schema_agent],
+    before_agent_callback=_before_devil,
+    after_agent_callback=_record_devil,
+)
 
-devil_agent.before_agent_callback = _ensure_debate_messages
+

--- a/judge/agents/moderator/tools.py
+++ b/judge/agents/moderator/tools.py
@@ -77,14 +77,7 @@ def should_stop(state) -> bool:
     )
 
 def ensure_debate_messages(callback_context=None, **_):
-    """
-    Ensure state['debate_messages'] exists to avoid KeyError in templates or code.
-    """
-    if callback_context is None:
-        return None
-    state = getattr(callback_context, "state", None)
-    if isinstance(state, dict):
-        state.setdefault("debate_messages", [])
+    """前置處理：目前無需額外動作，保留以維持介面一致。"""
     return None
 
 def log_turn(state: Dict[str, Any], speaker: str, output) -> None:
@@ -144,7 +137,6 @@ def log_tool_output(tool, args=None, tool_context=None, tool_response=None, resu
         if output:
             log_turn(st, speaker, output)
 
-        st.setdefault("debate_messages", [])
         def _get(obj, k, default=None):
             if obj is None:
                 return default

--- a/judge/agents/synthesizer/agent.py
+++ b/judge/agents/synthesizer/agent.py
@@ -13,6 +13,7 @@ class StakeSummary(BaseModel):
     strongest_points: List[str] = Field(description="2~5 條最強論點")
     weaknesses: List[str] = Field(description="2~5 條主要缺口/疑慮")
 
+
 class Contention(BaseModel):
     question: str = Field(description="爭點問題（單句）")
     what_advocates_say: List[str]
@@ -20,10 +21,12 @@ class Contention(BaseModel):
     what_devil_pushed: List[str] = Field(default_factory=list)
     status: str = Field(description="綜合判斷：共識 / 爭議中 / 證據不足 等")
 
+
 class RiskItem(BaseModel):
     name: str
     why: str
     mitigation: Optional[str] = None
+
 
 class FinalReport(BaseModel):
     topic: str
@@ -37,35 +40,25 @@ class FinalReport(BaseModel):
     open_questions: List[str] = Field(default_factory=list)
     appendix_links: List[str] = Field(default_factory=list, description="附錄連結（辯論日誌/原始證據等）")
 
-# ===== Synthesizer：整合所有 JSON 成為 FinalReport JSON =====
-synthesizer_agent = LlmAgent(
-    name="synthesizer",
-    model="gemini-2.5-flash",
-    instruction=(
-        "你是『知識整合者（Synthesizer）』。根據下列輸入生成最終報告的嚴格 JSON。\n\n"
-        "【輸入】\n"
-    "- CURATION(JSON): {curation}\n"
-    "- ADVOCACY(JSON): (the current advocacy JSON in state['advocacy'], if any)\n"
-    "- SKEPTICISM(JSON): (the current skepticism JSON in state['skepticism'], if any)\n"
-    "- (可選) DEVIL(JSON): (the optional devil turn stored in state['devil_turn'], if any)\n"
-    "- JURY(JSON): (the current jury result in state['jury_result'], if any)\n"
-    "- DEBATE LOG (messages array): (the current debate messages stored in state['debate_messages'])\n"
-    "- SOCIAL LOG(JSON): (the current social diffusion log stored in state['social_log'], if any)\n\n"
-        "【要求】\n"
-        "1) 僅輸出符合 FinalReport schema 的 JSON；不得有多餘文字。\n"
-        "2) overall_assessment 要清楚可執行；evidence_digest 列出最關鍵來源（含短說明、可附 URL）。\n"
-        "3) key_contentions 需能對照正反雙方觀點；若 devil_turn 存在，整合在 what_devil_pushed。\n"
-        "4) 若有 jury_result，填入 jury_score 與簡短 jury_brief（30 字內）。\n"
-        "5) appendix_links 可放『辯論日誌』或外部來源列表連結（若有）。"
-    ),
-    output_schema=FinalReport,
-    # 禁止傳遞以避免 output_schema 衝突
-    disallow_transfer_to_parent=True,
-    disallow_transfer_to_peers=True,
-    output_key="final_report_json",
-    # planner removed to avoid sending thinking config to model
-    generate_content_config=types.GenerateContentConfig(temperature=0.0),
-)
+
+# ---------- 同 Jury：前置處理，建立 fallacy_list ----------
+def _ensure_and_flatten_fallacies(callback_context=None, **_):
+    # 確保在執行前已有辯論紀錄，並扁平化所有謬誤
+    if callback_context is None:
+        return None
+    state = callback_context.state
+    flat = []
+    for msg in state["debate_messages"]:
+        falls = msg.get("fallacies") if isinstance(msg, dict) else getattr(msg, "fallacies", None)
+        if not falls:
+            continue
+        for f in falls:
+            if hasattr(f, "model_dump"):
+                flat.append(f.model_dump())
+            else:
+                flat.append(dict(f))
+    state["fallacy_list"] = flat
+    return None
 
 
 def _record_synthesis(agent_context=None, **_):
@@ -80,28 +73,36 @@ def _record_synthesis(agent_context=None, **_):
         )
     )
 
-synthesizer_agent.after_agent_callback = _record_synthesis
 
+# ===== Synthesizer：整合所有 JSON 成為 FinalReport JSON =====
+synthesizer_agent = LlmAgent(
+    name="synthesizer",
+    model="gemini-2.5-flash",
+    instruction=(
+        "你是『知識整合者（Synthesizer）』。根據下列輸入生成最終報告的嚴格 JSON。\n\n"
+        "【輸入】\n"
+        "- CURATION(JSON): {curation}\n"
+        "- ADVOCACY(JSON): (the current advocacy JSON in state['advocacy'], if any)\n"
+        "- SKEPTICISM(JSON): (the current skepticism JSON in state['skepticism'], if any)\n"
+        "- (可選) DEVIL(JSON): (the optional devil turn stored in state['devil_turn'], if any)\n"
+        "- JURY(JSON): (the current jury result in state['jury_result'], if any)\n"
+        "- DEBATE LOG (messages array): (the current debate messages stored in state['debate_messages'])\n"
+        "- SOCIAL LOG(JSON): (the current social diffusion log stored in state['social_log'], if any)\n\n"
+        "【要求】\n"
+        "1) 僅輸出符合 FinalReport schema 的 JSON；不得有多餘文字。\n"
+        "2) overall_assessment 要清楚可執行；evidence_digest 列出最關鍵來源（含短說明、可附 URL）。\n"
+        "3) key_contentions 需能對照正反雙方觀點；若 devil_turn 存在，整合在 what_devil_pushed。\n"
+        "4) 若有 jury_result，填入 jury_score 與簡短 jury_brief（30 字內）。\n"
+        "5) appendix_links 可放『辯論日誌』或外部來源列表連結（若有）。"
+    ),
+    output_schema=FinalReport,
+    # 禁止傳遞以避免 output_schema 衝突
+    disallow_transfer_to_parent=True,
+    disallow_transfer_to_peers=True,
+    output_key="final_report_json",
+    # planner removed to avoid sending thinking config to model
+    generate_content_config=types.GenerateContentConfig(temperature=0.0),
+    before_agent_callback=_ensure_and_flatten_fallacies,
+    after_agent_callback=_record_synthesis,
+)
 
-# ---------- 同 Jury：前置處理，建立 fallacy_list ----------
-def _ensure_and_flatten_fallacies(callback_context=None, **_):
-    # ensure debate_messages exists before running synthesizer
-    if callback_context is None:
-        return None
-    state = callback_context.state
-    state.setdefault("debate_messages", [])
-    flat = []
-    for msg in state["debate_messages"]:
-        falls = msg.get("fallacies") if isinstance(msg, dict) else getattr(msg, "fallacies", None)
-        if not falls:
-            continue
-        for f in falls:
-            if hasattr(f, "model_dump"):
-                flat.append(f.model_dump())
-            else:
-                flat.append(dict(f))
-    state["fallacy_list"] = flat
-    return None
-
-# 掛上前置處理
-synthesizer_agent.before_agent_callback = _ensure_and_flatten_fallacies

--- a/judge/tools/__init__.py
+++ b/judge/tools/__init__.py
@@ -29,8 +29,14 @@ from ._record_utils import (
 
 # 建立全域 InMemorySessionService 與 Session 物件
 session_service = InMemorySessionService()
+# 建立 Session 時統一指定初始 state
 SESSION: Session = session_service.create_session_sync(
-    app_name="agent_judge", user_id="user"
+    app_name="agent_judge",
+    user_id="user",
+    state={
+        "debate_messages": [],  # 儲存辯論訊息
+        "agents": [],           # 紀錄參與代理
+    },
 )
 
 
@@ -62,7 +68,6 @@ def _before_init_session(agent_context=None, **_):
     if agent_context is None:
         return None
     state = agent_context.state
-    state.setdefault("debate_messages", [])
     # 僅初始化辯論紀錄檔；state 變更將透過 session events 儲存
     initialize_debate_log("debate_log.json", state, reset=True)
     return None


### PR DESCRIPTION
## Summary
- 於 Session 建立時統一提供 `debate_messages` 與 `agents` 初始 state
- 移除多個模組中的 `state.setdefault`，以事件增量方式更新 state
- 各主要 agent 在建立時直接掛載前後置回呼以提升可讀性

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f81c32d8832381f51b8a669e783a