### PR TITLE
refactor debate log to session events

### DIFF
--- a/judge/agents/moderator/tools.py
+++ b/judge/agents/moderator/tools.py
@@ -1,26 +1,16 @@
 """主持人相關工具：提供退出迴圈與統計指標"""
 
 # --- moderator agent helpers moved from agent.py ---
-from typing import Dict, Any
-import json
+from typing import Any
 from pydantic import BaseModel
 from google.adk.tools.agent_tool import AgentTool
 
-from judge.tools import (
-    Turn,
-    append_turn,
-    initialize_debate_log,
-    load_debate_log,
-    append_event,
-)
+from judge.tools import append_event
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
 from judge.agents.advocate.agent import advocate_agent
 from judge.agents.skeptic.agent import skeptic_agent
 from judge.agents.devil.agent import devil_agent
-# 辯論紀錄檔路徑
-LOG_PATH = "debate_log.json"
-
 # 工具名稱與辯論記錄欄位對應
 LOG_MAP = {
     "call_advocate": ("advocate", "advocacy"),
@@ -43,15 +33,6 @@ def exit_loop(tool_context):
 
 def update_metrics(state):
     """更新並寫入爭點、可信度與證據的變化量（提取自原 loop.py）"""
-    # 若提供辯論紀錄路徑，先載入並更新目前指標
-    log_path = state.get("debate_log_path")
-    if log_path:
-        turns = load_debate_log(log_path)
-        state["dispute_points"] = len({t.claim for t in turns if t.claim})
-        confidences = [t.confidence for t in turns if t.confidence is not None]
-        state["credibility"] = sum(confidences) / len(confidences) if confidences else 0.0
-        state["evidence"] = [ev for t in turns for ev in t.evidence]
-
     prev_points = state.get("prev_dispute_points", 0)
     curr_points = state.get("dispute_points", 0)
     state["delta_dispute_points"] = curr_points - prev_points
@@ -80,51 +61,6 @@ def ensure_debate_messages(callback_context=None, **_):
     """前置處理：目前無需額外動作，保留以維持介面一致。"""
     return None
 
-def log_turn(state: Dict[str, Any], speaker: str, output) -> None:
-    """Append a Turn to the debate log based on an agent's output."""
-    log_path = state.get("debate_log_path")
-    if not log_path:
-        initialize_debate_log(LOG_PATH, state, reset=True)
-        log_path = state.get("debate_log_path")
-
-    def _get(obj, key, default=None):
-        if obj is None:
-            return default
-        if isinstance(obj, dict):
-            return obj.get(key, default)
-        return getattr(obj, key, default)
-
-    claim = _get(output, "thesis") or _get(output, "counter_thesis") or _get(output, "stance")
-
-    if hasattr(output, "model_dump_json"):
-        content = output.model_dump_json(ensure_ascii=False)
-    elif isinstance(output, dict):
-        content = json.dumps(output, ensure_ascii=False)
-    elif isinstance(output, str):
-        content = output
-    else:
-        try:
-            content = json.dumps(output, default=str, ensure_ascii=False)
-        except Exception:
-            content = str(output)
-
-    last_fallacies = None
-    msgs = state.get("debate_messages") or []
-    if msgs:
-        last = msgs[-1]
-        last_fallacies = (last.get("fallacies") if isinstance(last, dict)
-                        else getattr(last, "fallacies", None))
-
-    turn = Turn(
-        speaker=speaker,
-        content=content,
-        claim=claim,
-        confidence=_get(output, "confidence"),
-        evidence=_get(output, "evidence", []),
-        fallacies=last_fallacies or [],
-    )
-    append_turn(log_path, turn)
-    # NOTE: recording to state_record is handled by each agent's own callback
 
 def log_tool_output(tool, args=None, tool_context=None, tool_response=None, result=None, **_):
     response = tool_response if tool_response is not None else result
@@ -133,9 +69,6 @@ def log_tool_output(tool, args=None, tool_context=None, tool_response=None, resu
         speaker, key = info
         st = tool_context.state if tool_context is not None else {}
         output = st.get(key)
-
-        if output:
-            log_turn(st, speaker, output)
 
         def _get(obj, k, default=None):
             if obj is None:

--- a/judge/tools/_debate_log.py
+++ b/judge/tools/_debate_log.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from typing import List, Optional
-from pathlib import Path
 import json
-from pydantic import BaseModel,Field
+from pydantic import BaseModel, Field
+
+from google.adk.sessions.session import Session
 
 from .evidence import Evidence
 from ._record_utils import read_json_file, write_json_file
@@ -29,34 +30,90 @@ def save_debate_log(path: str, turns: List[Turn]) -> None:
     write_json_file(path, [t.model_dump() for t in turns])
 
 
-def append_turn(path: str, turn: Turn) -> None:
-    """附加單一回合到辯論紀錄檔"""
-    turns = load_debate_log(path)
+def append_turn(state: dict, turn: Turn) -> None:
+    """附加單一回合並即時更新指標。"""
+    turns: List[Turn] = state.setdefault("debate_log", [])
     turns.append(turn)
-    save_debate_log(path, turns)
 
-
-def initialize_debate_log(path: str, state: dict, reset: bool = True) -> None:
-    """初始化辯論紀錄檔
-
-    Args:
-        path: 紀錄檔路徑
-        state: 全域狀態，會寫入初始指標
-        reset: 是否清空舊紀錄
-    """
-    p = Path(path)
-    if reset and p.exists():
-        p.unlink()
-    turns = load_debate_log(path) if p.exists() else []
-    state["debate_log_path"] = path
-    # 初始化前次指標，供後續 Δ 計算
     claims = {t.claim for t in turns if t.claim}
     confidences = [t.confidence for t in turns if t.confidence is not None]
     evidences = [ev for t in turns for ev in t.evidence]
-    state["prev_dispute_points"] = len(claims)
-    state["prev_credibility"] = sum(confidences) / len(confidences) if confidences else 0.0
-    state["prev_evidence_count"] = len(evidences)
-    # 同步目前指標
-    state["dispute_points"] = state["prev_dispute_points"]
-    state["credibility"] = state["prev_credibility"]
+
+    state["dispute_points"] = len(claims)
+    state["credibility"] = sum(confidences) / len(confidences) if confidences else 0.0
     state["evidence"] = evidences
+
+
+def initialize_debate_log(path: str, state: dict, reset: bool = True) -> None:
+    """初始化辯論紀錄
+
+    Args:
+        path: 仍保留參數以維持介面相容
+        state: 全域狀態
+        reset: 是否重設現有紀錄
+    """
+    state["debate_log_path"] = path
+    if reset:
+        state["debate_log"] = []
+        state["dispute_points"] = 0
+        state["credibility"] = 0.0
+        state["evidence"] = []
+        state["prev_dispute_points"] = 0
+        state["prev_credibility"] = 0.0
+        state["prev_evidence_count"] = 0
+
+
+def _turns_from_session(session: Session) -> List[Turn]:
+    """從 Session 事件歷史擷取所有回合"""
+    turns: List[Turn] = []
+    seen = 0
+    for ev in session.events:
+        actions = getattr(ev, "actions", None)
+        if not actions or not getattr(actions, "state_delta", None):
+            continue
+        state_delta = actions.state_delta
+        msgs = state_delta.get("debate_messages")
+        if not isinstance(msgs, list):
+            continue
+        while seen < len(msgs):
+            msg = msgs[seen]
+            speaker = msg.get("speaker") or ev.author
+            content = msg.get("content")
+            if isinstance(content, (dict, list)):
+                content = json.dumps(content, ensure_ascii=False)
+            # 取出 state_delta 中第一個非辯論訊息的 payload 以取得信心與證據
+            payload = next((v for k, v in state_delta.items() if k != "debate_messages"), {})
+            confidence = payload.get("confidence") if isinstance(payload, dict) else None
+            evidence = payload.get("evidence", []) if isinstance(payload, dict) else []
+            turn = Turn(
+                speaker=speaker,
+                content=content or "",
+                claim=msg.get("claim"),
+                confidence=confidence,
+                evidence=evidence,
+                fallacies=msg.get("fallacies", []),
+            )
+            turns.append(turn)
+            seen += 1
+    return turns
+
+
+def update_state_from_session(state: dict, session: Session) -> None:
+    """重新計算指標並寫回 state"""
+    turns = _turns_from_session(session)
+    state["debate_log"] = turns
+
+    claims = {t.claim for t in turns if t.claim}
+    confidences = [t.confidence for t in turns if t.confidence is not None]
+    evidences = [ev for t in turns for ev in t.evidence]
+
+    state["dispute_points"] = len(claims)
+    state["credibility"] = sum(confidences) / len(confidences) if confidences else 0.0
+    state["evidence"] = evidences
+
+
+def export_debate_log(session: Session) -> str:
+    """將 Session 事件轉換為 Turn 陣列並輸出 JSON"""
+    turns = _turns_from_session(session)
+    data = [t.model_dump() for t in turns]
+    return json.dumps(data, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- derive debate turns and metrics from session events
- update state indicators when appending events
- add export_debate_log for JSON output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4fcf50a20832396a43c8b6c2e2fa1