### PR TITLE
整合 SessionService 建立與查詢流程

### DIFF
--- a/judge/agent.py
+++ b/judge/agent.py
@@ -8,7 +8,10 @@ from judge.agents import (
     jury_agent,
     synthesizer_agent,
 )
-from judge.tools import _before_init_session
+from judge.tools import _before_init_session, create_session
+
+# 啟動時建立 Session，初始化 state 與事件
+create_session()
 
 # =============== Root Pipeline ===============
 # 固定順序：Curator → Historian → 主持人回合制（正/反/極端）→ Social → Evidence → Jury → Synthesizer(JSON)


### PR DESCRIPTION
## Summary
- 啟動流程呼叫 `create_session`，集中管理辯論狀態
- 新增 `get_session` 與 `export_latest_debate_log` 以取得最新事件紀錄
- `append_event` 加入 Session 未初始化檢查，避免散亂紀錄

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5027a5c3083239ef624e5abd9a142