### PR TITLE
refactor: inject session service

### DIFF
--- a/judge/agents/advocate/agent.py
+++ b/judge/agents/advocate/agent.py
@@ -5,9 +5,9 @@ from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence
+from functools import partial
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 
 # ---- 讀 Curator 的證據結構（最小鏡像；如你已有型別可改 from ... import） ----
@@ -64,9 +64,9 @@ advocate_schema_agent = LlmAgent(
 )
 
 
-def _record_advocacy(agent_context=None, **_):
+def _record_advocacy(agent_context=None, append_event=None, **_):
     """after_agent_callback to append advocacy output to state_record if available"""
-    if agent_context is None:
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("advocacy")
@@ -78,7 +78,11 @@ def _record_advocacy(agent_context=None, **_):
         )
     )
 
-advocate_schema_agent.after_agent_callback = _record_advocacy
+
+def register_session(append_event):
+    advocate_schema_agent.after_agent_callback = partial(
+        _record_advocacy, append_event=append_event
+    )
 
 
 # Public advocate pipeline

--- a/judge/agents/curator/agent.py
+++ b/judge/agents/curator/agent.py
@@ -8,9 +8,9 @@ from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 # 採用絕對匯入以確保 Evidence 類別在各層級皆可正確引用
 from judge.tools.evidence import Evidence
+from functools import partial
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 
 # -------- Schema（輸入/輸出）---------
@@ -94,8 +94,8 @@ curator_agent = SequentialAgent(
 )
 
 
-def _record_curator(agent_context=None, **_):
-    if agent_context is None:
+def _record_curator(agent_context=None, append_event=None, **_):
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("curation")
@@ -106,5 +106,7 @@ def _record_curator(agent_context=None, **_):
         )
     )
 
-curator_agent.after_agent_callback = _record_curator
+
+def register_session(append_event):
+    curator_agent.after_agent_callback = partial(_record_curator, append_event=append_event)
 

--- a/judge/agents/devil/agent.py
+++ b/judge/agents/devil/agent.py
@@ -5,9 +5,9 @@ from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence
+from functools import partial
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 class DevilOutput(BaseModel):
     stance: str = Field(description="極端質疑的核心立場，單句")
@@ -47,8 +47,8 @@ devil_schema_agent = LlmAgent(
 )
 
 
-def _record_devil(agent_context=None, **_):
-    if agent_context is None:
+def _record_devil(agent_context=None, append_event=None, **_):
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("devil_turn")
@@ -70,7 +70,11 @@ devil_agent = SequentialAgent(
     name="devils_advocate",
     sub_agents=[devil_tool_agent, devil_schema_agent],
     before_agent_callback=_before_devil,
-    after_agent_callback=_record_devil,
+    after_agent_callback=None,
 )
+
+
+def register_session(append_event):
+    devil_agent.after_agent_callback = partial(_record_devil, append_event=append_event)
 
 

--- a/judge/agents/historian/agent.py
+++ b/judge/agents/historian/agent.py
@@ -3,9 +3,9 @@ from pydantic import BaseModel, Field
 
 from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
+from functools import partial
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 # ====== Schema 定義（輸出時間軸與宣傳模式）======
 class TimelineEvent(BaseModel):
@@ -45,8 +45,8 @@ historian_agent = SequentialAgent(
 )
 
 
-def _record_history(agent_context=None, **_):
-    if agent_context is None:
+def _record_history(agent_context=None, append_event=None, **_):
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("history")
@@ -57,4 +57,8 @@ def _record_history(agent_context=None, **_):
         )
     )
 
-historian_agent.after_agent_callback = _record_history
+
+def register_session(append_event):
+    historian_agent.after_agent_callback = partial(
+        _record_history, append_event=append_event
+    )

--- a/judge/agents/moderator/agent.py
+++ b/judge/agents/moderator/agent.py
@@ -6,6 +6,7 @@ referee LoopAgent. Helper functions and AgentTool wrappers live in
 `judge.agents.moderator.tools` to keep this file focused on orchestration.
 """
 
+from functools import partial
 from google.adk.agents import LlmAgent, SequentialAgent, LoopAgent
 from google.genai import types
 
@@ -55,7 +56,7 @@ executor_agent = LlmAgent(
     ),
     before_agent_callback=ensure_debate_messages,
     tools=[advocate_tool, skeptic_tool, devil_tool],
-    after_tool_callback=log_tool_output,
+    after_tool_callback=None,
     # no output_schema here because tools are used
     output_key="orchestrator_exec",
     # planner removed to avoid sending thinking config to model
@@ -92,3 +93,9 @@ referee_loop = LoopAgent(
     sub_agents=[social_noise_agent, orchestrator_agent, stop_checker],
     max_iterations=1,
 )
+
+
+def register_session(append_event):
+    executor_agent.after_tool_callback = partial(
+        log_tool_output, append_event=append_event
+    )

--- a/judge/agents/moderator/tools.py
+++ b/judge/agents/moderator/tools.py
@@ -5,7 +5,6 @@ from typing import Any
 from pydantic import BaseModel
 from google.adk.tools.agent_tool import AgentTool
 
-from judge.tools import append_event
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
 from judge.agents.advocate.agent import advocate_agent
@@ -62,7 +61,7 @@ def ensure_debate_messages(callback_context=None, **_):
     return None
 
 
-def log_tool_output(tool, args=None, tool_context=None, tool_response=None, result=None, **_):
+def log_tool_output(tool, args=None, tool_context=None, tool_response=None, result=None, append_event=None, **_):
     response = tool_response if tool_response is not None else result
     info = LOG_MAP.get(tool.name)
     if info:
@@ -91,7 +90,7 @@ def log_tool_output(tool, args=None, tool_context=None, tool_response=None, resu
         })
         # also write to state_record and keep in-memory agent log
         sr_path = st.get("state_record_path")
-        if sr_path:
+        if sr_path and append_event is not None:
             try:
                 # 將工具輸出記錄為事件並更新 state
                 append_event(

--- a/judge/agents/skeptic/agent.py
+++ b/judge/agents/skeptic/agent.py
@@ -6,9 +6,9 @@ from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence  # 使用絕對匯入以避免路徑問題
+from functools import partial
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 
 # ---- 方便比對 Advocate / Curator 內容 ----
@@ -69,8 +69,8 @@ skeptic_schema_agent = LlmAgent(
 )
 
 
-def _record_skepticism(agent_context=None, **_):
-    if agent_context is None:
+def _record_skepticism(agent_context=None, append_event=None, **_):
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("skepticism")
@@ -81,7 +81,11 @@ def _record_skepticism(agent_context=None, **_):
         )
     )
 
-skeptic_schema_agent.after_agent_callback = _record_skepticism
+
+def register_session(append_event):
+    skeptic_schema_agent.after_agent_callback = partial(
+        _record_skepticism, append_event=append_event
+    )
 
 skeptic_agent = SequentialAgent(
     name="skeptic",

--- a/judge/agents/social/agent.py
+++ b/judge/agents/social/agent.py
@@ -1,9 +1,9 @@
 from pydantic import BaseModel, Field
 
+from functools import partial
 from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 
 # ==== 社群擴散紀錄 Schema ====
@@ -83,8 +83,8 @@ social_summary_agent = SequentialAgent(
 )
 
 
-def _record_social(agent_context=None, **_):
-    if agent_context is None:
+def _record_social(agent_context=None, append_event=None, **_):
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("social_log")
@@ -95,4 +95,8 @@ def _record_social(agent_context=None, **_):
         )
     )
 
-social_summary_agent.after_agent_callback = _record_social
+
+def register_session(append_event):
+    social_summary_agent.after_agent_callback = partial(
+        _record_social, append_event=append_event
+    )

--- a/judge/agents/social_noise/agent.py
+++ b/judge/agents/social_noise/agent.py
@@ -1,9 +1,9 @@
 from pydantic import BaseModel, Field
 
 from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
+from functools import partial
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
-from judge.tools import append_event
 
 
 # ==== 社群噪音紀錄 Schema ====
@@ -73,8 +73,8 @@ social_noise_agent = SequentialAgent(
 )
 
 
-def _record_social_noise(agent_context=None, **_):
-    if agent_context is None:
+def _record_social_noise(agent_context=None, append_event=None, **_):
+    if agent_context is None or append_event is None:
         return None
     state = agent_context.state
     output = state.get("social_noise")
@@ -85,4 +85,8 @@ def _record_social_noise(agent_context=None, **_):
         )
     )
 
-social_noise_agent.after_agent_callback = _record_social_noise
+
+def register_session(append_event):
+    social_noise_agent.after_agent_callback = partial(
+        _record_social_noise, append_event=append_event
+    )


### PR DESCRIPTION
## Summary
- remove global session and creation helpers
- inject session via bind functions for all agents
- initialize session service in entry point

## Testing
- `python -m pytest`
- `python -m compileall judge`


------
https://chatgpt.com/codex/tasks/task_e_68c51b20a4008323a5c63e8a7c137925