### PR TITLE
移除 sr_path 並改以 Session 事件紀錄輸出

### DIFF
--- a/judge/agents/moderator/tools.py
+++ b/judge/agents/moderator/tools.py
@@ -88,11 +88,9 @@ def log_tool_output(tool, args=None, tool_context=None, tool_response=None, resu
             "content": payload,
             "claim": claim,
         })
-        # also write to state_record and keep in-memory agent log
-        sr_path = st.get("state_record_path")
-        if sr_path and append_event is not None:
+        # 透過 Session 事件紀錄輸出，避免重複紀錄
+        if append_event is not None:
             try:
-                # 將工具輸出記錄為事件並更新 state
                 append_event(
                     Event(
                         author=speaker,


### PR DESCRIPTION
## 摘要
- 移除 `log_tool_output` 中的 `sr_path` 相關程式
- 透過 `append_event` 單一路徑紀錄工具輸出，避免雙重紀錄

## 測試
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c51d754bcc8323b0d31b567551e6e8