### PR TITLE
feat: centralize event recording callback

### DIFF
--- a/judge/agents/advocate/agent.py
+++ b/judge/agents/advocate/agent.py
@@ -5,9 +5,8 @@ from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence
+from judge.tools import make_record_callback
 from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 
 # ---- 讀 Curator 的證據結構（最小鏡像；如你已有型別可改 from ... import） ----
@@ -64,24 +63,9 @@ advocate_schema_agent = LlmAgent(
 )
 
 
-def _record_advocacy(agent_context=None, append_event=None, **_):
-    """after_agent_callback to append advocacy output to state_record if available"""
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("advocacy")
-    # 使用 Session 事件記錄最新的正方輸出
-    append_event(
-        Event(
-            author="advocate",
-            actions=EventActions(state_delta={"advocacy": output}),
-        )
-    )
-
-
 def register_session(append_event):
     advocate_schema_agent.after_agent_callback = partial(
-        _record_advocacy, append_event=append_event
+        make_record_callback("advocate", "advocacy"), append_event=append_event
     )
 
 

--- a/judge/agents/curator/agent.py
+++ b/judge/agents/curator/agent.py
@@ -8,9 +8,8 @@ from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 # 採用絕對匯入以確保 Evidence 類別在各層級皆可正確引用
 from judge.tools.evidence import Evidence
+from judge.tools import make_record_callback
 from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 
 # -------- Schema（輸入/輸出）---------
@@ -94,19 +93,8 @@ curator_agent = SequentialAgent(
 )
 
 
-def _record_curator(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("curation")
-    append_event(
-        Event(
-            author="curator",
-            actions=EventActions(state_delta={"curation": output}),
-        )
-    )
-
-
 def register_session(append_event):
-    curator_agent.after_agent_callback = partial(_record_curator, append_event=append_event)
+    curator_agent.after_agent_callback = partial(
+        make_record_callback("curator", "curation"), append_event=append_event
+    )
 

--- a/judge/agents/evidence/agent.py
+++ b/judge/agents/evidence/agent.py
@@ -6,9 +6,8 @@ from google.adk.tools.google_search_tool import GoogleSearchTool
 from google.genai import types
 
 from judge.tools.evidence import Evidence
+from judge.tools import make_record_callback
 from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 
 # ==== 查核結果資料模型 ====
@@ -51,19 +50,6 @@ _evidence_schema_agent = LlmAgent(
 )
 
 
-def _record_evidence(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("evidence_report") or state.get("evidence")
-    append_event(
-        Event(
-            author="evidence",
-            actions=EventActions(state_delta={"evidence": output}),
-        )
-    )
-
-
 # 保留前置處理介面，目前無需額外動作
 def _before_evidence(agent_context=None, **_):
     return None
@@ -80,5 +66,5 @@ evidence_agent = SequentialAgent(
 
 def register_session(append_event):
     evidence_agent.after_agent_callback = partial(
-        _record_evidence, append_event=append_event
+        make_record_callback("evidence", "evidence"), append_event=append_event
     )


### PR DESCRIPTION
## Summary
- centralize event recording via make_record_callback
- refactor advocate, curator, evidence agents to use shared callback

## Testing
- `pytest`
- `python -m py_compile judge/tools/__init__.py judge/agents/advocate/agent.py judge/agents/curator/agent.py judge/agents/evidence/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68c523bcc0d083238b440b2110dd9a01