### PR TITLE
centralize agent event registration

### DIFF
--- a/judge/agent.py
+++ b/judge/agent.py
@@ -8,51 +8,19 @@ from google.adk.sessions.session import Session
 
 from judge.services.session import session_service
 
-from judge.agents.advocate.agent import (
-    advocate_agent,
-    register_session as register_advocate,
-)
-from judge.agents.curator.agent import (
-    curator_agent,
-    register_session as register_curator,
-)
-from judge.agents.devil.agent import (
-    devil_agent,
-    register_session as register_devil,
-)
-from judge.agents.evidence.agent import (
-    evidence_agent,
-    register_session as register_evidence,
-)
-from judge.agents.historian.agent import (
-    historian_agent,
-    register_session as register_historian,
-)
-from judge.agents.jury.agent import (
-    jury_agent,
-    register_session as register_jury,
-)
-from judge.agents.moderator.agent import (
-    referee_loop,
-    register_session as register_moderator,
-)
-from judge.agents.skeptic.agent import (
-    skeptic_agent,
-    register_session as register_skeptic,
-)
-from judge.agents.social.agent import (
-    social_summary_agent,
-    register_session as register_social,
-)
-from judge.agents.social_noise.agent import (
-    social_noise_agent,
-    register_session as register_social_noise,
-)
-from judge.agents.synthesizer.agent import (
-    synthesizer_agent,
-    register_session as register_synthesizer,
-)
-from judge.tools import _before_init_session, append_event
+from judge.agents.advocate.agent import advocate_agent, advocate_schema_agent
+from judge.agents.curator.agent import curator_agent
+from judge.agents.devil.agent import devil_agent
+from judge.agents.evidence.agent import evidence_agent
+from judge.agents.historian.agent import historian_agent
+from judge.agents.jury.agent import jury_agent
+from judge.agents.moderator.agent import referee_loop, executor_agent
+from judge.agents.moderator.tools import log_tool_output
+from judge.agents.skeptic.agent import skeptic_agent, skeptic_schema_agent
+from judge.agents.social.agent import social_summary_agent
+from judge.agents.social_noise.agent import social_noise_agent
+from judge.agents.synthesizer.agent import synthesizer_agent
+from judge.tools import _before_init_session, append_event, make_record_callback
 
 
 def create_session(state: dict | None = None) -> Session:
@@ -75,17 +43,31 @@ def bind_session(session: Session) -> None:
     """將 append_event 函式注入各代理，避免全域依賴"""
 
     append_event_fn = partial(append_event, session, service=session_service)
-    register_curator(append_event_fn)
-    register_historian(append_event_fn)
-    register_social(append_event_fn)
-    register_evidence(append_event_fn)
-    register_jury(append_event_fn)
-    register_synthesizer(append_event_fn)
-    register_skeptic(append_event_fn)
-    register_advocate(append_event_fn)
-    register_devil(append_event_fn)
-    register_social_noise(append_event_fn)
-    register_moderator(append_event_fn)
+
+    # 統一列出需要寫入事件的代理與對應鍵值
+    agent_event_map = [
+        (curator_agent, "curator", "curation"),
+        (historian_agent, "historian", "history"),
+        (social_summary_agent, "social", "social_log"),
+        (evidence_agent, "evidence", "evidence"),
+        (jury_agent, "jury", "jury_result"),
+        (synthesizer_agent, "synthesizer", "final_report_json"),
+        (advocate_schema_agent, "advocate", "advocacy"),
+        (skeptic_schema_agent, "skeptic", "skepticism"),
+        (devil_agent, "devil", "devil_turn"),
+        (social_noise_agent, "social_noise", "social_noise"),
+    ]
+
+    # 迴圈設定 after_agent_callback，透過 make_record_callback 統一寫入事件
+    for agent, author, key in agent_event_map:
+        agent.after_agent_callback = partial(
+            make_record_callback(author, key), append_event=append_event_fn
+        )
+
+    # 主持人執行器需額外紀錄工具輸出
+    executor_agent.after_tool_callback = partial(
+        log_tool_output, append_event=append_event_fn
+    )
 
 
 # =============== Root Pipeline ===============

--- a/judge/agents/advocate/agent.py
+++ b/judge/agents/advocate/agent.py
@@ -5,8 +5,6 @@ from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence
-from judge.tools import make_record_callback
-from functools import partial
 
 
 # ---- 讀 Curator 的證據結構（最小鏡像；如你已有型別可改 from ... import） ----
@@ -61,12 +59,6 @@ advocate_schema_agent = LlmAgent(
     # planner removed to avoid sending thinking config to model
     generate_content_config=types.GenerateContentConfig(temperature=0.4),
 )
-
-
-def register_session(append_event):
-    advocate_schema_agent.after_agent_callback = partial(
-        make_record_callback("advocate", "advocacy"), append_event=append_event
-    )
 
 
 # Public advocate pipeline

--- a/judge/agents/curator/agent.py
+++ b/judge/agents/curator/agent.py
@@ -8,8 +8,6 @@ from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 # 採用絕對匯入以確保 Evidence 類別在各層級皆可正確引用
 from judge.tools.evidence import Evidence
-from judge.tools import make_record_callback
-from functools import partial
 
 
 # -------- Schema（輸入/輸出）---------
@@ -91,10 +89,4 @@ curator_agent = SequentialAgent(
     name="curator",
     sub_agents=[curator_tool_agent, curator_schema_agent],
 )
-
-
-def register_session(append_event):
-    curator_agent.after_agent_callback = partial(
-        make_record_callback("curator", "curation"), append_event=append_event
-    )
 

--- a/judge/agents/devil/agent.py
+++ b/judge/agents/devil/agent.py
@@ -5,9 +5,6 @@ from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence
-from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 class DevilOutput(BaseModel):
     stance: str = Field(description="極端質疑的核心立場，單句")
@@ -47,19 +44,6 @@ devil_schema_agent = LlmAgent(
 )
 
 
-def _record_devil(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("devil_turn")
-    append_event(
-        Event(
-            author="devil",
-            actions=EventActions(state_delta={"devil_turn": output}),
-        )
-    )
-
-
 # 保留前置處理介面，目前無需額外動作
 def _before_devil(agent_context=None, **_):
     return None
@@ -72,9 +56,5 @@ devil_agent = SequentialAgent(
     before_agent_callback=_before_devil,
     after_agent_callback=None,
 )
-
-
-def register_session(append_event):
-    devil_agent.after_agent_callback = partial(_record_devil, append_event=append_event)
 
 

--- a/judge/agents/evidence/agent.py
+++ b/judge/agents/evidence/agent.py
@@ -6,8 +6,6 @@ from google.adk.tools.google_search_tool import GoogleSearchTool
 from google.genai import types
 
 from judge.tools.evidence import Evidence
-from judge.tools import make_record_callback
-from functools import partial
 
 
 # ==== 查核結果資料模型 ====
@@ -64,7 +62,3 @@ evidence_agent = SequentialAgent(
 )
 
 
-def register_session(append_event):
-    evidence_agent.after_agent_callback = partial(
-        make_record_callback("evidence", "evidence"), append_event=append_event
-    )

--- a/judge/agents/historian/agent.py
+++ b/judge/agents/historian/agent.py
@@ -3,9 +3,6 @@ from pydantic import BaseModel, Field
 
 from google.adk.agents import LlmAgent, SequentialAgent
 from google.genai import types
-from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 # ====== Schema 定義（輸出時間軸與宣傳模式）======
 class TimelineEvent(BaseModel):
@@ -43,22 +40,3 @@ historian_agent = SequentialAgent(
     name="historian",
     sub_agents=[historian_llm_agent],
 )
-
-
-def _record_history(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("history")
-    append_event(
-        Event(
-            author="historian",
-            actions=EventActions(state_delta={"history": output}),
-        )
-    )
-
-
-def register_session(append_event):
-    historian_agent.after_agent_callback = partial(
-        _record_history, append_event=append_event
-    )

--- a/judge/agents/moderator/agent.py
+++ b/judge/agents/moderator/agent.py
@@ -6,14 +6,12 @@ referee LoopAgent. Helper functions and AgentTool wrappers live in
 `judge.agents.moderator.tools` to keep this file focused on orchestration.
 """
 
-from functools import partial
 from google.adk.agents import LlmAgent, SequentialAgent, LoopAgent
 from google.genai import types
 
 from .tools import (
     exit_loop,
     ensure_debate_messages,
-    log_tool_output,
     advocate_tool,
     skeptic_tool,
     devil_tool,
@@ -93,9 +91,3 @@ referee_loop = LoopAgent(
     sub_agents=[social_noise_agent, orchestrator_agent, stop_checker],
     max_iterations=1,
 )
-
-
-def register_session(append_event):
-    executor_agent.after_tool_callback = partial(
-        log_tool_output, append_event=append_event
-    )

--- a/judge/agents/skeptic/agent.py
+++ b/judge/agents/skeptic/agent.py
@@ -6,9 +6,6 @@ from google.adk.planners import BuiltInPlanner
 from google.genai import types
 from google.adk.tools.google_search_tool import GoogleSearchTool
 from judge.tools.evidence import Evidence  # 使用絕對匯入以避免路徑問題
-from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 
 # ---- 方便比對 Advocate / Curator 內容 ----
@@ -67,25 +64,6 @@ skeptic_schema_agent = LlmAgent(
     output_key="skepticism",
     generate_content_config=types.GenerateContentConfig(temperature=0.0),
 )
-
-
-def _record_skepticism(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("skepticism")
-    append_event(
-        Event(
-            author="skeptic",
-            actions=EventActions(state_delta={"skepticism": output}),
-        )
-    )
-
-
-def register_session(append_event):
-    skeptic_schema_agent.after_agent_callback = partial(
-        _record_skepticism, append_event=append_event
-    )
 
 skeptic_agent = SequentialAgent(
     name="skeptic",

--- a/judge/agents/social/agent.py
+++ b/judge/agents/social/agent.py
@@ -1,9 +1,6 @@
 from pydantic import BaseModel, Field
 
-from functools import partial
 from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 
 # ==== 社群擴散紀錄 Schema ====
@@ -81,22 +78,3 @@ social_summary_agent = SequentialAgent(
     name="social_summary",
     sub_agents=[_social_parallel, _social_aggregator],
 )
-
-
-def _record_social(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("social_log")
-    append_event(
-        Event(
-            author="social",
-            actions=EventActions(state_delta={"social_log": output}),
-        )
-    )
-
-
-def register_session(append_event):
-    social_summary_agent.after_agent_callback = partial(
-        _record_social, append_event=append_event
-    )

--- a/judge/agents/social_noise/agent.py
+++ b/judge/agents/social_noise/agent.py
@@ -1,9 +1,6 @@
 from pydantic import BaseModel, Field
 
 from google.adk.agents import LlmAgent, ParallelAgent, SequentialAgent
-from functools import partial
-from google.adk.events.event import Event
-from google.adk.events.event_actions import EventActions
 
 
 # ==== 社群噪音紀錄 Schema ====
@@ -71,22 +68,3 @@ social_noise_agent = SequentialAgent(
     name="social_noise",
     sub_agents=[_social_noise_parallel, _noise_aggregator],
 )
-
-
-def _record_social_noise(agent_context=None, append_event=None, **_):
-    if agent_context is None or append_event is None:
-        return None
-    state = agent_context.state
-    output = state.get("social_noise")
-    append_event(
-        Event(
-            author="social_noise",
-            actions=EventActions(state_delta={"social_noise": output}),
-        )
-    )
-
-
-def register_session(append_event):
-    social_noise_agent.after_agent_callback = partial(
-        _record_social_noise, append_event=append_event
-    )


### PR DESCRIPTION
## Summary
- consolidate agent event registration in `judge/agent.py` with a unified map and loop using `make_record_callback`
- remove `register_session` helpers from individual agent modules
- ensure moderator executor still logs tool outputs

## Testing
- `python -m py_compile judge/agent.py judge/agents/advocate/agent.py judge/agents/curator/agent.py judge/agents/devil/agent.py judge/agents/evidence/agent.py judge/agents/historian/agent.py judge/agents/jury/agent.py judge/agents/moderator/agent.py judge/agents/skeptic/agent.py judge/agents/social/agent.py judge/agents/social_noise/agent.py judge/agents/synthesizer/agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c57ead8fb88323b36d939cd2892f37