### PR TITLE
refactor: async session event handling

### DIFF
--- a/judge/agent.py
+++ b/judge/agent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from functools import partial
 
 from google.adk.agents import LlmAgent, SequentialAgent
@@ -24,18 +23,17 @@ from judge.tools import _before_init_session, append_event, make_record_callback
 
 
 def create_session(state: dict | None = None) -> Session:
-    """建立新的 Session"""
+    """建立新的 Session（同步呼叫版）"""
 
-    return asyncio.run(
-        session_service.create_session(
-            app_name="agent_judge",
-            user_id="user",
-            state=state
-            or {
-                "debate_messages": [],
-                "agents": [],
-            },
-        )
+    # 使用 google.adk 提供的同步 API，避免在此處建立事件迴圈
+    return session_service.create_session_sync(
+        app_name="agent_judge",
+        user_id="user",
+        state=state
+        or {
+            "debate_messages": [],
+            "agents": [],
+        },
     )
 
 

--- a/judge/agents/moderator/tools.py
+++ b/judge/agents/moderator/tools.py
@@ -61,7 +61,7 @@ def ensure_debate_messages(callback_context=None, **_):
     return None
 
 
-def log_tool_output(tool, args=None, tool_context=None, tool_response=None, result=None, append_event=None, **_):
+async def log_tool_output(tool, args=None, tool_context=None, tool_response=None, result=None, append_event=None, **_):
     response = tool_response if tool_response is not None else result
     info = LOG_MAP.get(tool.name)
     if info:
@@ -91,7 +91,8 @@ def log_tool_output(tool, args=None, tool_context=None, tool_response=None, resu
         # 透過 Session 事件紀錄輸出，避免重複紀錄
         if append_event is not None:
             try:
-                append_event(
+                # 非同步寫入事件，確保與代理共用事件迴圈
+                await append_event(
                     Event(
                         author=speaker,
                         actions=EventActions(


### PR DESCRIPTION
## Summary
- use google.adk's sync `create_session_sync`
- make session event helpers async and await inside callbacks
- rewrite moderator tool logging to await event appends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c583e78648832393f9eec345afe106